### PR TITLE
Add Minecraft tech-tree execution-layer benchmark

### DIFF
--- a/PhyAgentOS/benchmarks/__init__.py
+++ b/PhyAgentOS/benchmarks/__init__.py
@@ -1,0 +1,2 @@
+"""Benchmark modules for PhyAgentOS."""
+

--- a/PhyAgentOS/benchmarks/minecraft/__init__.py
+++ b/PhyAgentOS/benchmarks/minecraft/__init__.py
@@ -1,0 +1,2 @@
+"""Minecraft benchmark modules."""
+

--- a/PhyAgentOS/benchmarks/minecraft/techtree/README.md
+++ b/PhyAgentOS/benchmarks/minecraft/techtree/README.md
@@ -1,0 +1,221 @@
+# Minecraft Tech-Tree Benchmark
+
+The Minecraft tech-tree benchmark is an executor-independent, standalone
+obtain-item benchmark for standard Minecraft item progression.  Its tasks are
+derived from and vetted against MineStudio-style task configs plus a standard
+Minecraft tech-tree taxonomy, then reimplemented as PhyAgentOS-owned task
+definitions with programmatic scoring.
+
+This is not an official MineStudio, MCU, MineEvolve, TeamCraft, or VPT
+benchmark protocol, and its numbers should not be compared to those public
+leaderboards.
+
+## Scope
+
+This is an execution-layer benchmark.  The reference adapter resets each task
+into an isolated arena, places required materials or target blocks near the
+agent, provides target coordinates through the task setup, and gives the
+prerequisite tools declared by the task.  It measures whether an injected agent
+can execute low-level Minecraft actions, including local navigation, digging,
+pickup, crafting, placing, and smelting, once materials are staged, targets are
+localized, and prerequisites are available.
+
+It does not measure open-world exploration, resource search, visual target
+localization, high-level planning, long-horizon reasoning, or climbing the real
+Minecraft dependency chain.  The tech-tree tiers are difficulty and category
+labels; they are not a dependency chain that the agent must discover or execute
+across tasks.
+
+The benchmark core does not run an agent by itself.  It exposes a small API:
+
+1. load a task from `manifest.json`;
+2. set up the world through an injected `WorldAdapter`;
+3. call an injected `agent_fn`;
+4. evaluate the final observation with deterministic inventory/state checks.
+
+No LLM, VLM, watchdog, session runner, governance, skill induction, or workspace
+state is required by the core package.
+
+## Package Layout
+
+| File | Purpose |
+|---|---|
+| `manifest.json` | Vetted 40-task tech-tree manifest |
+| `schema.py` | Dataclasses for tasks, arena setup, and success criteria |
+| `loader.py` | `load_manifest`, `list_tasks`, `load_task` |
+| `evaluator.py` | Programmatic inventory evaluator |
+| `harness.py` | Executor-independent `run_task` harness |
+| `adapters/mineflayer_bridge.py` | Optional reference adapter for a mineflayer HTTP bridge |
+
+## Public API
+
+```python
+from PhyAgentOS.benchmarks.minecraft.techtree import (
+    evaluate_task,
+    list_tasks,
+    load_task,
+    run_task,
+)
+
+task = load_task("wooden.obtain_oak_log")
+verdict = evaluate_task(task, {"inventory": {"oak_log": 1}})
+print(verdict.success)
+```
+
+To run an agent, inject your own world adapter and agent function:
+
+```python
+from PhyAgentOS.benchmarks.minecraft.techtree import run_task
+
+
+def my_agent(task, world):
+    # The benchmark does not care how this agent works.
+    # It may be scripted, LLM-driven, policy-driven, or another system.
+    return {"ok": True}
+
+
+result = run_task("wooden.obtain_oak_log", my_agent, my_world_adapter)
+print(result.success, result.reward)
+```
+
+`my_world_adapter` only needs two methods:
+
+```python
+class WorldAdapter:
+    def reset(self, setup):
+        ...
+
+    def observe(self):
+        ...
+```
+
+The optional `MineflayerBridgeAdapter` demonstrates how a mineflayer HTTP bridge
+can implement that interface.  It is deliberately isolated under `adapters/` so
+the benchmark core remains executor-independent.
+
+## Reset And Arena Isolation
+
+Task setup describes a fixed local arena in addition to inventory and task
+blocks.  The default arena origin is `[-2000, 80, -2000]`; the reference
+mineflayer adapter teleports the bot there, clears a bounded box, lays a fixed
+floor, marks the boundary, then places task blocks at fixed coordinates relative
+to the arena origin.
+
+This makes reference-adapter runs reproducible inside the arena and avoids
+accidentally using old world terrain around the bot.  The benchmark does not
+claim to recreate a full Minecraft world seed or terrain distribution.
+
+## Scoring
+
+Version 1 uses deterministic programmatic criteria.  Most tasks use:
+
+```json
+{"type": "inventory_contains", "item": "<target_item>", "count": 1}
+```
+
+The evaluator accepts common Minecraft observation shapes:
+
+- `{"inventory": {"oak_log": 1}}`
+- `{"inventory": {"counts": {"oak_log": 1}}}`
+- `{"inventory_items": [{"name": "minecraft:oak_log", "count": 1}]}`
+- `{"info": {"inventory_items": [...]}}`
+
+Reward is `1.0` for success and `0.0` otherwise.  Repeated trials are
+recommended because Minecraft execution loops can be non-deterministic even
+when the initial task definition is fixed.
+
+## Task List
+
+### Wooden
+
+| id | target_item | family | source |
+|---|---|---|---|
+| `wooden.obtain_oak_log` | `oak_log` | `dig_pickup` | collect_wood |
+| `wooden.obtain_dirt` | `dirt` | `dig_pickup` | mine_dirt |
+| `wooden.obtain_grass_block` | `grass_block` | `dig_pickup` | collect_grass |
+| `wooden.craft_oak_planks` | `oak_planks` | `crafting_inventory` | craft_the_crafting_table |
+| `wooden.craft_stick` | `stick` | `crafting_inventory` | tool_bow |
+| `wooden.craft_crafting_table` | `crafting_table` | `crafting_inventory` | craft_table |
+| `wooden.craft_chest` | `chest` | `crafting_table` | prepare_a_birthday_present_for_your_neighbor |
+| `wooden.craft_ladder` | `ladder` | `crafting_table` | craft_ladder, craft_to_ladder |
+| `wooden.craft_bow` | `bow` | `crafting_table` | tool_bow |
+| `wooden.craft_wooden_pickaxe` | `wooden_pickaxe` | `crafting_table` | survive_plant |
+
+### Stone
+
+| id | target_item | family | source |
+|---|---|---|---|
+| `stone.obtain_cobblestone` | `cobblestone` | `dig_pickup` | cut_stone |
+| `stone.craft_stone_pickaxe` | `stone_pickaxe` | `crafting_table` | cut_stone |
+| `stone.craft_stone_axe` | `stone_axe` | `crafting_table` | collect_wood |
+| `stone.craft_stone_shovel` | `stone_shovel` | `crafting_table` | mine_dirt |
+| `stone.craft_stone_sword` | `stone_sword` | `crafting_table` | survive_combat |
+| `stone.craft_furnace` | `furnace` | `crafting_table` | craft_smelting |
+| `stone.craft_stonecutter` | `stonecutter` | `crafting_table` | craft_stonecut |
+| `stone.craft_torch` | `torch` | `crafting_inventory` | find_diamond |
+
+### Iron
+
+| id | target_item | family | source |
+|---|---|---|---|
+| `iron.obtain_coal` | `coal` | `dig_pickup` | mine_iron_ore |
+| `iron.obtain_raw_iron` | `raw_iron` | `dig_pickup` | mine_iron_ore |
+| `iron.smelt_iron_ingot` | `iron_ingot` | `smelting` | craft_smelting |
+| `iron.craft_iron_pickaxe` | `iron_pickaxe` | `crafting_table` | mine_obsidian |
+| `iron.craft_iron_axe` | `iron_axe` | `crafting_table` | clean_up |
+| `iron.craft_iron_shovel` | `iron_shovel` | `crafting_table` | dig_three_down_and_fill_one_up |
+| `iron.craft_iron_sword` | `iron_sword` | `crafting_table` | enchant_sword |
+| `iron.craft_bucket` | `bucket` | `crafting_table` | craft_to_cake |
+| `iron.craft_shears` | `shears` | `crafting_inventory` | collect_wool |
+
+### Gold-Redstone
+
+| id | target_item | family | source |
+|---|---|---|---|
+| `gold_redstone.obtain_raw_gold` | `raw_gold` | `dig_pickup` | craft_to_clock |
+| `gold_redstone.smelt_gold_ingot` | `gold_ingot` | `smelting` | craft_to_clock |
+| `gold_redstone.obtain_redstone` | `redstone` | `dig_pickup` | craft_to_clock |
+| `gold_redstone.craft_clock` | `clock` | `crafting_table` | craft_to_clock |
+| `gold_redstone.craft_compass` | `compass` | `crafting_table` | find_village |
+
+### Diamond
+
+| id | target_item | family | source |
+|---|---|---|---|
+| `diamond.obtain_diamond` | `diamond` | `dig_pickup` | find_diamond, mine_diamond_ore |
+| `diamond.obtain_obsidian` | `obsidian` | `dig_pickup` | mine_obsidian |
+| `diamond.craft_diamond_pickaxe` | `diamond_pickaxe` | `crafting_table` | mine_obsidian |
+| `diamond.craft_enchanting_table` | `enchanting_table` | `crafting_table` | craft_enchantment |
+
+### Armor
+
+| id | target_item | family | source |
+|---|---|---|---|
+| `armor.craft_iron_helmet` | `iron_helmet` | `crafting_table` | survive_combat |
+| `armor.craft_iron_chestplate` | `iron_chestplate` | `crafting_table` | survive_combat |
+| `armor.craft_diamond_helmet` | `diamond_helmet` | `crafting_table` | enchant_diamond_sword |
+| `armor.craft_diamond_chestplate` | `diamond_chestplate` | `crafting_table` | enchant_diamond_sword |
+
+## Limitations
+
+- This is a vetted, standalone reimplementation derived from MineStudio-style
+  task configs and Minecraft tech-tree tiers.  It is not the official
+  MineStudio, MCU, MineEvolve, TeamCraft, or VPT benchmark protocol, and scores
+  are not directly comparable to external leaderboard numbers.
+- This is an execution-layer obtain-item benchmark.  Each task runs in an
+  isolated arena with materials or target blocks placed near the agent, target
+  coordinates available through setup, and prerequisite tools provided.  Scores
+  measure whether the agent can execute low-level Minecraft actions after setup,
+  not whether it can discover resources or plan the dependency chain.
+- It does not measure open-world exploration, resource search, visual target
+  localization, high-level planning, long-horizon reasoning, or true tech-tree
+  climbing.  The tech-tree tiers are difficulty and category labels, not a
+  dependency chain that the agent must execute across tasks.
+- It uses programmatic inventory/state checks, not visual judgment.
+- The reference adapter isolates each task inside a fixed, cleaned arena with
+  relative task placement.  It does not regenerate a full world seed or natural
+  terrain distribution.
+- A task definition can be deterministic while a Minecraft execution loop is
+  still non-deterministic.  Use multiple repetitions when reporting scores.
+- The core harness is single-agent by default.  Multi-agent or OS session
+  execution should wrap this package rather than modifying the core benchmark.

--- a/PhyAgentOS/benchmarks/minecraft/techtree/__init__.py
+++ b/PhyAgentOS/benchmarks/minecraft/techtree/__init__.py
@@ -1,0 +1,44 @@
+"""Executor-independent Minecraft tech-tree benchmark."""
+
+from PhyAgentOS.benchmarks.minecraft.techtree.evaluator import (
+    EvaluationResult,
+    evaluate_task,
+    inventory_count,
+    inventory_counts,
+)
+from PhyAgentOS.benchmarks.minecraft.techtree.harness import BenchmarkResult, run_task
+from PhyAgentOS.benchmarks.minecraft.techtree.loader import load_manifest, load_task, list_tasks
+from PhyAgentOS.benchmarks.minecraft.techtree.schema import (
+    DEFAULT_ARENA_BOUNDARY_BLOCK,
+    DEFAULT_ARENA_CLEAR_HEIGHT,
+    DEFAULT_ARENA_CLEAR_RADIUS,
+    DEFAULT_ARENA_FLOOR_BLOCK,
+    DEFAULT_ARENA_ORIGIN,
+    ArenaSetup,
+    SuccessCriterion,
+    TaskManifest,
+    TechTreeTask,
+    WorldSetup,
+)
+
+__all__ = [
+    "BenchmarkResult",
+    "ArenaSetup",
+    "DEFAULT_ARENA_BOUNDARY_BLOCK",
+    "DEFAULT_ARENA_CLEAR_HEIGHT",
+    "DEFAULT_ARENA_CLEAR_RADIUS",
+    "DEFAULT_ARENA_FLOOR_BLOCK",
+    "DEFAULT_ARENA_ORIGIN",
+    "EvaluationResult",
+    "SuccessCriterion",
+    "TaskManifest",
+    "TechTreeTask",
+    "WorldSetup",
+    "evaluate_task",
+    "inventory_count",
+    "inventory_counts",
+    "list_tasks",
+    "load_manifest",
+    "load_task",
+    "run_task",
+]

--- a/PhyAgentOS/benchmarks/minecraft/techtree/adapters/__init__.py
+++ b/PhyAgentOS/benchmarks/minecraft/techtree/adapters/__init__.py
@@ -1,0 +1,2 @@
+"""Optional world adapters for the Minecraft tech-tree benchmark."""
+

--- a/PhyAgentOS/benchmarks/minecraft/techtree/adapters/mineflayer_bridge.py
+++ b/PhyAgentOS/benchmarks/minecraft/techtree/adapters/mineflayer_bridge.py
@@ -1,0 +1,120 @@
+"""Reference world adapter for a mineflayer HTTP bridge.
+
+This adapter is intentionally outside the benchmark core.  Users may provide
+their own adapter as long as it implements ``reset(setup)`` and ``observe()``.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+import httpx
+
+from PhyAgentOS.benchmarks.minecraft.techtree.schema import ArenaSetup, SetupItem, WorldSetup
+
+
+@dataclass
+class MineflayerBridgeAdapter:
+    bridge_url: str = "http://127.0.0.1:3000"
+    timeout_s: float = 20.0
+    verify_ssl: bool = False
+
+    def reset(self, setup: WorldSetup) -> Mapping[str, Any]:
+        self._set_phase("reset", reset_counters=True)
+        try:
+            if setup.arena.enabled:
+                self._prepare_arena(setup.arena)
+            if setup.clear_inventory:
+                self._command("/clear @s")
+            for item in setup.inventory:
+                self._command(_give_command(item))
+            origin = setup.arena.origin if setup.arena.enabled else _origin_from_state(self.observe())
+            for block in setup.blocks:
+                x = origin[0] + block.relative[0]
+                y = origin[1] + block.relative[1]
+                z = origin[2] + block.relative[2]
+                self._command(f"/setblock {x} {y} {z} {_minecraft_name(block.block)}")
+            return self.observe()
+        finally:
+            self._set_phase("idle", reset_counters=False)
+
+    def observe(self) -> Mapping[str, Any]:
+        with httpx.Client(timeout=self.timeout_s, verify=self.verify_ssl, trust_env=False) as client:
+            response = client.get(f"{self.bridge_url.rstrip('/')}/state")
+            response.raise_for_status()
+            return response.json()
+
+    def execute_action(self, action: str, params: Mapping[str, Any] | None = None) -> Mapping[str, Any]:
+        with httpx.Client(timeout=self.timeout_s, verify=self.verify_ssl, trust_env=False) as client:
+            response = client.post(
+                f"{self.bridge_url.rstrip('/')}/action",
+                json={"action": action, "params": dict(params or {})},
+            )
+            response.raise_for_status()
+            return response.json()
+
+    def _command(self, command: str) -> Mapping[str, Any]:
+        return self.execute_action("chat", {"message": command, "allowCommand": True})
+
+    def _prepare_arena(self, arena: ArenaSetup) -> None:
+        x, y, z = arena.origin
+        radius = max(1, int(arena.clear_radius))
+        height = max(1, int(arena.clear_height))
+        floor_y = y - 1
+        min_x = x - radius
+        max_x = x + radius
+        min_z = z - radius
+        max_z = z + radius
+        self._command(f"/tp @s {x} {y} {z} 0 0")
+        self._command(f"/fill {min_x} {y} {min_z} {max_x} {y + height} {max_z} air")
+        self._command(
+            f"/fill {min_x} {floor_y} {min_z} {max_x} {floor_y} {max_z} "
+            f"{_minecraft_name(arena.floor_block)}"
+        )
+        boundary = _minecraft_name(arena.boundary_block)
+        self._command(f"/fill {min_x} {floor_y} {min_z} {max_x} {floor_y} {min_z} {boundary}")
+        self._command(f"/fill {min_x} {floor_y} {max_z} {max_x} {floor_y} {max_z} {boundary}")
+        self._command(f"/fill {min_x} {floor_y} {min_z} {min_x} {floor_y} {max_z} {boundary}")
+        self._command(f"/fill {max_x} {floor_y} {min_z} {max_x} {floor_y} {max_z} {boundary}")
+
+    def _set_phase(self, phase: str, *, reset_counters: bool) -> None:
+        with httpx.Client(timeout=self.timeout_s, verify=self.verify_ssl, trust_env=False) as client:
+            response = client.post(
+                f"{self.bridge_url.rstrip('/')}/phase",
+                json={"phase": phase, "reset_counters": reset_counters, "source": "minecraft_techtree"},
+            )
+            response.raise_for_status()
+
+
+def _give_command(item: SetupItem) -> str:
+    item_name = _minecraft_name(item.item)
+    suffix = ""
+    if item.enchantments:
+        entries = []
+        for enchantment in item.enchantments:
+            enchant_id = str(enchantment.get("id") or "").replace("minecraft:", "")
+            level = int(enchantment.get("level", 1) or 1)
+            entries.append(f'{{id:"minecraft:{enchant_id}",lvl:{level}}}')
+        suffix = "{Enchantments:[" + ",".join(entries) + "]}"
+    return f"/give @s {item_name}{suffix} {max(1, int(item.count or 1))}"
+
+
+def _minecraft_name(name: str) -> str:
+    return name if name.startswith("minecraft:") else f"minecraft:{name}"
+
+
+def _origin_from_state(state: Mapping[str, Any]) -> tuple[int, int, int]:
+    position = state.get("position")
+    if not isinstance(position, Mapping):
+        bot = state.get("bot")
+        if isinstance(bot, Mapping):
+            position = bot.get("position")
+    if not isinstance(position, Mapping):
+        raise ValueError("bridge state does not contain bot position")
+    return (
+        math.floor(float(position.get("x", 0))),
+        math.floor(float(position.get("y", 0))),
+        math.floor(float(position.get("z", 0))),
+    )

--- a/PhyAgentOS/benchmarks/minecraft/techtree/evaluator.py
+++ b/PhyAgentOS/benchmarks/minecraft/techtree/evaluator.py
@@ -1,0 +1,110 @@
+"""Programmatic evaluators for Minecraft tech-tree observations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from PhyAgentOS.benchmarks.minecraft.techtree.schema import TechTreeTask
+
+
+@dataclass(frozen=True)
+class EvaluationResult:
+    success: bool
+    reward: float
+    reason: str
+    metrics: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "success": self.success,
+            "reward": self.reward,
+            "reason": self.reason,
+            "metrics": dict(self.metrics),
+        }
+
+
+def evaluate_task(task: TechTreeTask, observation: Mapping[str, Any] | None) -> EvaluationResult:
+    """Evaluate a task against a normalized or raw Minecraft observation."""
+
+    observation = observation or {}
+    criterion = task.success_criterion
+    if criterion.type != "inventory_contains":
+        return EvaluationResult(
+            success=False,
+            reward=0.0,
+            reason=f"unsupported_success_criterion:{criterion.type}",
+            metrics={"criterion": criterion.to_dict()},
+        )
+
+    item = criterion.item or task.target_item
+    observed = inventory_count(observation, item)
+    success = observed >= criterion.count
+    return EvaluationResult(
+        success=success,
+        reward=1.0 if success else 0.0,
+        reason="inventory_contains" if success else "inventory_missing",
+        metrics={
+            "target_item": item,
+            "required_count": criterion.count,
+            "observed_count": observed,
+            "inventory_counts": inventory_counts(observation),
+        },
+    )
+
+
+def inventory_count(observation: Mapping[str, Any], item_name: str) -> int:
+    return inventory_counts(observation).get(normalize_item_name(item_name), 0)
+
+
+def inventory_counts(observation: Mapping[str, Any]) -> dict[str, int]:
+    """Extract item counts from common Minecraft observation shapes."""
+
+    counts: dict[str, int] = {}
+
+    def add(name: Any, count: Any = 1) -> None:
+        if not name:
+            return
+        key = normalize_item_name(str(name))
+        try:
+            amount = int(count or 0)
+        except (TypeError, ValueError):
+            amount = 1
+        counts[key] = counts.get(key, 0) + max(0, amount)
+
+    def read_item_list(items: Any) -> bool:
+        if not isinstance(items, list):
+            return False
+        found = False
+        for item in items:
+            if isinstance(item, Mapping):
+                add(item.get("name") or item.get("item"), item.get("count", 1))
+                found = True
+        return found
+
+    found_items = read_item_list(observation.get("inventory_items"))
+    info = observation.get("info")
+    if isinstance(info, Mapping):
+        found_items = read_item_list(info.get("inventory_items")) or found_items
+    if found_items:
+        return counts
+
+    inventory = observation.get("inventory")
+    if isinstance(inventory, Mapping):
+        raw_counts = inventory.get("counts") if isinstance(inventory.get("counts"), Mapping) else inventory
+        for name, count in raw_counts.items():
+            if isinstance(count, Mapping):
+                add(name, count.get("count", 1))
+            else:
+                add(name, count)
+    elif isinstance(inventory, list):
+        read_item_list(inventory)
+
+    return counts
+
+
+def normalize_item_name(name: str) -> str:
+    name = str(name).strip().lower()
+    if name.startswith("minecraft:"):
+        return name.split(":", 1)[1]
+    return name

--- a/PhyAgentOS/benchmarks/minecraft/techtree/harness.py
+++ b/PhyAgentOS/benchmarks/minecraft/techtree/harness.py
@@ -1,0 +1,116 @@
+"""Executor-independent harness for Minecraft tech-tree tasks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Mapping, Protocol
+
+from PhyAgentOS.benchmarks.minecraft.techtree.evaluator import EvaluationResult, evaluate_task
+from PhyAgentOS.benchmarks.minecraft.techtree.loader import load_task
+from PhyAgentOS.benchmarks.minecraft.techtree.schema import TechTreeTask, WorldSetup
+
+
+class WorldAdapter(Protocol):
+    """Minimal world interface required by the benchmark core."""
+
+    def reset(self, setup: WorldSetup) -> Mapping[str, Any]:
+        ...
+
+    def observe(self) -> Mapping[str, Any]:
+        ...
+
+
+AgentFn = Callable[[TechTreeTask, WorldAdapter], Any]
+
+
+@dataclass(frozen=True)
+class BenchmarkResult:
+    task_id: str
+    started_at: str
+    finished_at: str
+    success: bool
+    reward: float
+    verdict: EvaluationResult
+    initial_observation: Mapping[str, Any] | None = None
+    final_observation: Mapping[str, Any] | None = None
+    agent_result: Any = None
+    error: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "success": self.success,
+            "reward": self.reward,
+            "verdict": self.verdict.to_dict(),
+            "initial_observation": self.initial_observation,
+            "final_observation": self.final_observation,
+            "agent_result": self.agent_result,
+            "error": self.error,
+            "metadata": dict(self.metadata),
+        }
+
+
+def run_task(
+    task_id: str,
+    agent_fn: AgentFn,
+    world_adapter: WorldAdapter,
+    *,
+    manifest_path: str | Path | None = None,
+) -> BenchmarkResult:
+    """Run one task with an injected agent and world adapter.
+
+    The benchmark core does not know how the agent acts.  It only sets up the
+    world through ``world_adapter``, gives the structured task to ``agent_fn``,
+    observes the final state, and scores that state with deterministic code.
+    """
+
+    task = load_task(task_id, manifest_path)
+    started = _utc_now()
+    initial_observation: Mapping[str, Any] | None = None
+    final_observation: Mapping[str, Any] | None = None
+    agent_result: Any = None
+    error: str | None = None
+
+    try:
+        initial_observation = world_adapter.reset(task.setup)
+        agent_result = agent_fn(task, world_adapter)
+    except Exception as exc:  # pragma: no cover - exercised by harness users
+        error = f"{type(exc).__name__}: {exc}"
+    finally:
+        try:
+            final_observation = world_adapter.observe()
+        except Exception as exc:  # pragma: no cover - exercised by harness users
+            if error is None:
+                error = f"{type(exc).__name__}: {exc}"
+
+    verdict = evaluate_task(task, final_observation or {})
+    if error and not verdict.success:
+        verdict = EvaluationResult(
+            success=False,
+            reward=0.0,
+            reason="agent_or_world_error",
+            metrics={**verdict.metrics, "error": error, "original_reason": verdict.reason},
+        )
+
+    return BenchmarkResult(
+        task_id=task.id,
+        started_at=started,
+        finished_at=_utc_now(),
+        success=verdict.success,
+        reward=verdict.reward,
+        verdict=verdict,
+        initial_observation=initial_observation,
+        final_observation=final_observation,
+        agent_result=agent_result,
+        error=error,
+        metadata={"benchmark": "minecraft_techtree", "tier": task.tier, "family": task.family},
+    )
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/PhyAgentOS/benchmarks/minecraft/techtree/loader.py
+++ b/PhyAgentOS/benchmarks/minecraft/techtree/loader.py
@@ -1,0 +1,65 @@
+"""Manifest loader for the Minecraft tech-tree benchmark."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from PhyAgentOS.benchmarks.minecraft.techtree.schema import TaskManifest, TechTreeTask
+
+DEFAULT_MANIFEST_PATH = Path(__file__).with_name("manifest.json")
+
+
+def load_manifest(path: str | Path | None = None) -> TaskManifest:
+    """Load the tech-tree manifest from JSON."""
+
+    manifest_path = Path(path) if path is not None else DEFAULT_MANIFEST_PATH
+    data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest = TaskManifest.from_dict(data)
+    _validate_manifest(manifest)
+    return manifest
+
+
+def list_tasks(
+    *,
+    tier: str | None = None,
+    family: str | None = None,
+    manifest_path: str | Path | None = None,
+) -> list[TechTreeTask]:
+    """List manifest tasks, optionally filtering by tier or family."""
+
+    tasks = list(load_manifest(manifest_path).tasks)
+    if tier is not None:
+        tasks = [task for task in tasks if task.tier == tier]
+    if family is not None:
+        tasks = [task for task in tasks if task.family == family]
+    return tasks
+
+
+def load_task(task_id: str, manifest_path: str | Path | None = None) -> TechTreeTask:
+    """Load a single task by id."""
+
+    manifest = load_manifest(manifest_path)
+    tasks = manifest.task_map()
+    try:
+        return tasks[task_id]
+    except KeyError as exc:
+        available = ", ".join(sorted(tasks))
+        raise KeyError(f"unknown Minecraft tech-tree task {task_id!r}; available: {available}") from exc
+
+
+def _validate_manifest(manifest: TaskManifest) -> None:
+    seen: set[str] = set()
+    for task in manifest.tasks:
+        if task.id in seen:
+            raise ValueError(f"duplicate task id: {task.id}")
+        seen.add(task.id)
+        if not task.target_item:
+            raise ValueError(f"{task.id}: target_item is required")
+        if task.success_criterion.type != "inventory_contains":
+            raise ValueError(f"{task.id}: unsupported success criterion {task.success_criterion.type!r}")
+        if task.success_criterion.item != task.target_item:
+            raise ValueError(f"{task.id}: success criterion item must match target_item")
+        initial_items = {item.item for item in task.setup.inventory}
+        if task.target_item in initial_items:
+            raise ValueError(f"{task.id}: setup inventory already contains target_item {task.target_item!r}")

--- a/PhyAgentOS/benchmarks/minecraft/techtree/manifest.json
+++ b/PhyAgentOS/benchmarks/minecraft/techtree/manifest.json
@@ -1,0 +1,964 @@
+{
+  "version": "minecraft_techtree_benchmark_v1",
+  "name": "minecraft_techtree",
+  "description": "Executor-independent Minecraft tech-tree benchmark with vetted obtain-item tasks and programmatic inventory/state scoring.",
+  "status": "phase1_vetted_manifest",
+  "source_notes": {
+    "mine_studio_root_used_for_vetting": "E:/xm_phyagentos/benchmarks_external/MineStudio/minestudio/benchmark/task_configs",
+    "external_taxonomy": [
+      "MineStudio task_configs simple/hard",
+      "MCU/MineEvolve-style tiers: Wooden, Stone, Iron, Gold-Redstone, Diamond, Armor"
+    ],
+    "self_contained_pr_policy": "Task definitions below do not require the external MineStudio files at runtime. MineStudio task ids are provenance only."
+  },
+  "vetting_policy": {
+    "target_item_required": true,
+    "non_degenerate_setup": "setup must not place the target item in inventory before the agent acts",
+    "programmatic_success": "success is checked from inventory or simple world state; no VLM and no LLM judging",
+    "executor_independent": "tasks describe setup and success only; benchmark core must not import or require a specific agent, runtime, watchdog, governance, or workspace",
+    "allowed_mechanics": [
+      "dig and pickup",
+      "inventory crafting",
+      "crafting table crafting",
+      "furnace smelting",
+      "simple block placement for setup"
+    ],
+    "excluded_mechanics": [
+      "pixel-only exploration",
+      "trading",
+      "shearing or entity-specific behavior unless separately modeled",
+      "combat-only goals",
+      "complex redstone construction",
+      "tasks that are already complete after reset"
+    ]
+  },
+  "success_defaults": {
+    "type": "inventory_contains",
+    "count": 1
+  },
+  "tasks": [
+    {
+      "id": "wooden.obtain_oak_log",
+      "tier": "Wooden",
+      "family": "dig_pickup",
+      "title": "Obtain oak log",
+      "target_item": "oak_log",
+      "success_criterion": {"type": "inventory_contains", "item": "oak_log", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "wooden_axe", "count": 1}],
+        "blocks": [{"block": "oak_log", "relative": [2, 0, 0]}]
+      },
+      "source_refs": [{"kind": "MineStudio", "task": "collect_wood", "difficulty": "simple"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "MineStudio collect_wood gives an axe and expects oak_log collection; setup makes a nearby target explicit."
+      }
+    },
+    {
+      "id": "wooden.obtain_dirt",
+      "tier": "Wooden",
+      "family": "dig_pickup",
+      "title": "Obtain dirt",
+      "target_item": "dirt",
+      "success_criterion": {"type": "inventory_contains", "item": "dirt", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "wooden_shovel", "count": 1}],
+        "blocks": [{"block": "dirt", "relative": [2, 0, 0]}]
+      },
+      "source_refs": [{"kind": "MineStudio", "task": "mine_dirt", "difficulty": "simple"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "Uses mine_dirt instead of collect_dirt because collect_dirt reset gives dirt in inventory."
+      }
+    },
+    {
+      "id": "wooden.obtain_grass_block",
+      "tier": "Wooden",
+      "family": "dig_pickup",
+      "title": "Obtain grass block",
+      "target_item": "grass_block",
+      "success_criterion": {"type": "inventory_contains", "item": "grass_block", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "diamond_shovel", "count": 1, "enchantments": [{"id": "silk_touch", "level": 1}]}],
+        "blocks": [{"block": "grass_block", "relative": [2, 0, 0]}]
+      },
+      "source_refs": [{"kind": "MineStudio", "task": "collect_grass", "difficulty": "simple"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "Requires silk touch; ordinary mine_grass is excluded because it drops dirt."
+      }
+    },
+    {
+      "id": "wooden.craft_oak_planks",
+      "tier": "Wooden",
+      "family": "crafting_inventory",
+      "title": "Craft oak planks",
+      "target_item": "oak_planks",
+      "success_criterion": {"type": "inventory_contains", "item": "oak_planks", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "oak_log", "count": 1}]
+      },
+      "source_refs": [{"kind": "MineStudio", "task": "craft_the_crafting_table", "difficulty": "simple"}, {"kind": "TechTree", "tier": "Wooden"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "Standard log-to-planks recipe; no planks are pre-given."
+      }
+    },
+    {
+      "id": "wooden.craft_stick",
+      "tier": "Wooden",
+      "family": "crafting_inventory",
+      "title": "Craft sticks",
+      "target_item": "stick",
+      "success_criterion": {"type": "inventory_contains", "item": "stick", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "oak_planks", "count": 2}]
+      },
+      "source_refs": [{"kind": "MineStudio", "task": "tool_bow", "difficulty": "simple"}, {"kind": "TechTree", "tier": "Wooden"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "Standard planks-to-sticks recipe."
+      }
+    },
+    {
+      "id": "wooden.craft_crafting_table",
+      "tier": "Wooden",
+      "family": "crafting_inventory",
+      "title": "Craft crafting table",
+      "target_item": "crafting_table",
+      "success_criterion": {"type": "inventory_contains", "item": "crafting_table", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "oak_planks", "count": 4}]
+      },
+      "source_refs": [{"kind": "MineStudio", "task": "craft_table", "difficulty": "simple"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "craft_table target is minecraft:crafting_table, not table."
+      }
+    },
+    {
+      "id": "wooden.craft_chest",
+      "tier": "Wooden",
+      "family": "crafting_table",
+      "title": "Craft chest",
+      "target_item": "chest",
+      "success_criterion": {"type": "inventory_contains", "item": "chest", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "oak_planks", "count": 8}, {"item": "crafting_table", "count": 1}]
+      },
+      "source_refs": [{"kind": "MineStudio", "task": "prepare_a_birthday_present_for_your_neighbor", "difficulty": "simple"}, {"kind": "TechTree", "tier": "Wooden"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "MineStudio uses chests in a broader task; this isolates the standard chest recipe."
+      }
+    },
+    {
+      "id": "wooden.craft_ladder",
+      "tier": "Wooden",
+      "family": "crafting_table",
+      "title": "Craft ladder",
+      "target_item": "ladder",
+      "success_criterion": {"type": "inventory_contains", "item": "ladder", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "stick", "count": 7}, {"item": "crafting_table", "count": 1}]
+      },
+      "source_refs": [{"kind": "MineStudio", "task": "craft_ladder", "difficulty": "simple"}, {"kind": "MineStudio", "task": "craft_to_ladder", "difficulty": "simple"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "Existing MineStudio ladder tasks pre-give sticks, not ladders."
+      }
+    },
+    {
+      "id": "wooden.craft_bow",
+      "tier": "Wooden",
+      "family": "crafting_table",
+      "title": "Craft bow",
+      "target_item": "bow",
+      "success_criterion": {"type": "inventory_contains", "item": "bow", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "stick", "count": 3}, {"item": "string", "count": 3}, {"item": "crafting_table", "count": 1}]
+      },
+      "source_refs": [{"kind": "MineStudio", "task": "tool_bow", "difficulty": "simple"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "tool_bow gives stick and string; target is bow."
+      }
+    },
+    {
+      "id": "wooden.craft_wooden_pickaxe",
+      "tier": "Wooden",
+      "family": "crafting_table",
+      "title": "Craft wooden pickaxe",
+      "target_item": "wooden_pickaxe",
+      "success_criterion": {"type": "inventory_contains", "item": "wooden_pickaxe", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "oak_planks", "count": 3}, {"item": "stick", "count": 2}, {"item": "crafting_table", "count": 1}]
+      },
+      "source_refs": [{"kind": "TechTree", "tier": "Wooden"}, {"kind": "MineStudio", "task": "survive_plant", "difficulty": "simple"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "Standard wooden tool milestone; MineStudio uses wooden_pickaxe as a provided prerequisite in survive_plant."
+      }
+    },
+    {
+      "id": "stone.obtain_cobblestone",
+      "tier": "Stone",
+      "family": "dig_pickup",
+      "title": "Obtain cobblestone",
+      "target_item": "cobblestone",
+      "success_criterion": {"type": "inventory_contains", "item": "cobblestone", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "wooden_pickaxe", "count": 1}],
+        "blocks": [{"block": "stone", "relative": [2, 0, 0]}]
+      },
+      "source_refs": [{"kind": "MineStudio", "task": "cut_stone", "difficulty": "simple"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "Mining stone yields cobblestone."
+      }
+    },
+    {
+      "id": "stone.craft_stone_pickaxe",
+      "tier": "Stone",
+      "family": "crafting_table",
+      "title": "Craft stone pickaxe",
+      "target_item": "stone_pickaxe",
+      "success_criterion": {"type": "inventory_contains", "item": "stone_pickaxe", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "cobblestone", "count": 3}, {"item": "stick", "count": 2}, {"item": "crafting_table", "count": 1}]
+      },
+      "source_refs": [{"kind": "TechTree", "tier": "Stone"}, {"kind": "MineStudio", "task": "cut_stone", "difficulty": "hard"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "Standard prerequisite for iron ore mining."
+      }
+    },
+    {
+      "id": "stone.craft_stone_axe",
+      "tier": "Stone",
+      "family": "crafting_table",
+      "title": "Craft stone axe",
+      "target_item": "stone_axe",
+      "success_criterion": {"type": "inventory_contains", "item": "stone_axe", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "cobblestone", "count": 3}, {"item": "stick", "count": 2}, {"item": "crafting_table", "count": 1}]
+      },
+      "source_refs": [{"kind": "TechTree", "tier": "Stone"}, {"kind": "MineStudio", "task": "collect_wood", "difficulty": "hard"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "Standard stone tool; MineStudio hard collect_wood provides stone_axe as a prerequisite."
+      }
+    },
+    {
+      "id": "stone.craft_stone_shovel",
+      "tier": "Stone",
+      "family": "crafting_table",
+      "title": "Craft stone shovel",
+      "target_item": "stone_shovel",
+      "success_criterion": {"type": "inventory_contains", "item": "stone_shovel", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "cobblestone", "count": 1}, {"item": "stick", "count": 2}, {"item": "crafting_table", "count": 1}]
+      },
+      "source_refs": [{"kind": "TechTree", "tier": "Stone"}, {"kind": "MineStudio", "task": "mine_dirt", "difficulty": "hard"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "Standard shovel recipe."
+      }
+    },
+    {
+      "id": "stone.craft_stone_sword",
+      "tier": "Stone",
+      "family": "crafting_table",
+      "title": "Craft stone sword",
+      "target_item": "stone_sword",
+      "success_criterion": {"type": "inventory_contains", "item": "stone_sword", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "cobblestone", "count": 2}, {"item": "stick", "count": 1}, {"item": "crafting_table", "count": 1}]
+      },
+      "source_refs": [{"kind": "TechTree", "tier": "Stone"}, {"kind": "MineStudio", "task": "survive_combat", "difficulty": "hard"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "Standard weapon milestone; combat variants are excluded, this only scores inventory."
+      }
+    },
+    {
+      "id": "stone.craft_furnace",
+      "tier": "Stone",
+      "family": "crafting_table",
+      "title": "Craft furnace",
+      "target_item": "furnace",
+      "success_criterion": {"type": "inventory_contains", "item": "furnace", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "cobblestone", "count": 8}, {"item": "crafting_table", "count": 1}]
+      },
+      "source_refs": [{"kind": "MineStudio", "task": "craft_smelting", "difficulty": "simple"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "MineStudio craft_smelting text is furnace crafting; target is furnace."
+      }
+    },
+    {
+      "id": "stone.craft_stonecutter",
+      "tier": "Stone",
+      "family": "crafting_table",
+      "title": "Craft stonecutter",
+      "target_item": "stonecutter",
+      "success_criterion": {"type": "inventory_contains", "item": "stonecutter", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "stone", "count": 3}, {"item": "iron_ingot", "count": 1}, {"item": "crafting_table", "count": 1}]
+      },
+      "source_refs": [{"kind": "MineStudio", "task": "craft_stonecut", "difficulty": "simple"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "Isolated standard stonecutter recipe."
+      }
+    },
+    {
+      "id": "stone.craft_torch",
+      "tier": "Stone",
+      "family": "crafting_inventory",
+      "title": "Craft torch",
+      "target_item": "torch",
+      "success_criterion": {"type": "inventory_contains", "item": "torch", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "coal", "count": 1}, {"item": "stick", "count": 1}]
+      },
+      "source_refs": [{"kind": "MineStudio", "task": "find_diamond", "difficulty": "hard"}, {"kind": "TechTree", "tier": "Stone"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "Torch is a standard mining support item; MineStudio hard find_diamond provides torches as prerequisites."
+      }
+    },
+    {
+      "id": "iron.obtain_coal",
+      "tier": "Iron",
+      "family": "dig_pickup",
+      "title": "Obtain coal",
+      "target_item": "coal",
+      "success_criterion": {"type": "inventory_contains", "item": "coal", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "stone_pickaxe", "count": 1}],
+        "blocks": [{"block": "coal_ore", "relative": [2, 0, 0]}]
+      },
+      "source_refs": [{"kind": "TechTree", "tier": "Iron"}, {"kind": "MineStudio", "task": "mine_iron_ore", "difficulty": "hard"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "No exact collect_coal YAML exists; this is a standard ore-drop task."
+      }
+    },
+    {
+      "id": "iron.obtain_raw_iron",
+      "tier": "Iron",
+      "family": "dig_pickup",
+      "title": "Obtain raw iron",
+      "target_item": "raw_iron",
+      "success_criterion": {"type": "inventory_contains", "item": "raw_iron", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "stone_pickaxe", "count": 1}],
+        "blocks": [{"block": "iron_ore", "relative": [2, 0, 0]}]
+      },
+      "source_refs": [{"kind": "MineStudio", "task": "mine_iron_ore", "difficulty": "simple"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "Mining iron_ore yields raw_iron in modern Minecraft."
+      }
+    },
+    {
+      "id": "iron.smelt_iron_ingot",
+      "tier": "Iron",
+      "family": "smelting",
+      "title": "Smelt iron ingot",
+      "target_item": "iron_ingot",
+      "success_criterion": {"type": "inventory_contains", "item": "iron_ingot", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "raw_iron", "count": 1}, {"item": "coal", "count": 1}, {"item": "furnace", "count": 1}]
+      },
+      "source_refs": [{"kind": "MineStudio", "task": "craft_smelting", "difficulty": "hard"}, {"kind": "TechTree", "tier": "Iron"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "Furnace and ingredients are prerequisites; target ingot is not pre-given."
+      }
+    },
+    {
+      "id": "iron.craft_iron_pickaxe",
+      "tier": "Iron",
+      "family": "crafting_table",
+      "title": "Craft iron pickaxe",
+      "target_item": "iron_pickaxe",
+      "success_criterion": {"type": "inventory_contains", "item": "iron_pickaxe", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "iron_ingot", "count": 3}, {"item": "stick", "count": 2}, {"item": "crafting_table", "count": 1}]
+      },
+      "source_refs": [{"kind": "TechTree", "tier": "Iron"}, {"kind": "MineStudio", "task": "mine_obsidian", "difficulty": "simple"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "Standard iron tool milestone."
+      }
+    },
+    {
+      "id": "iron.craft_iron_axe",
+      "tier": "Iron",
+      "family": "crafting_table",
+      "title": "Craft iron axe",
+      "target_item": "iron_axe",
+      "success_criterion": {"type": "inventory_contains", "item": "iron_axe", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "iron_ingot", "count": 3}, {"item": "stick", "count": 2}, {"item": "crafting_table", "count": 1}]
+      },
+      "source_refs": [{"kind": "TechTree", "tier": "Iron"}, {"kind": "MineStudio", "task": "clean_up", "difficulty": "simple"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "Standard iron tool; clean_up demonstrates tool use but is not used as a benchmark task."
+      }
+    },
+    {
+      "id": "iron.craft_iron_shovel",
+      "tier": "Iron",
+      "family": "crafting_table",
+      "title": "Craft iron shovel",
+      "target_item": "iron_shovel",
+      "success_criterion": {"type": "inventory_contains", "item": "iron_shovel", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "iron_ingot", "count": 1}, {"item": "stick", "count": 2}, {"item": "crafting_table", "count": 1}]
+      },
+      "source_refs": [{"kind": "MineStudio", "task": "dig_three_down_and_fill_one_up", "difficulty": "simple"}, {"kind": "TechTree", "tier": "Iron"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "Standard iron shovel recipe."
+      }
+    },
+    {
+      "id": "iron.craft_iron_sword",
+      "tier": "Iron",
+      "family": "crafting_table",
+      "title": "Craft iron sword",
+      "target_item": "iron_sword",
+      "success_criterion": {"type": "inventory_contains", "item": "iron_sword", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "iron_ingot", "count": 2}, {"item": "stick", "count": 1}, {"item": "crafting_table", "count": 1}]
+      },
+      "source_refs": [{"kind": "MineStudio", "task": "enchant_sword", "difficulty": "hard"}, {"kind": "TechTree", "tier": "Iron"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "Combat tasks are excluded; this isolates the inventory craft."
+      }
+    },
+    {
+      "id": "iron.craft_bucket",
+      "tier": "Iron",
+      "family": "crafting_table",
+      "title": "Craft bucket",
+      "target_item": "bucket",
+      "success_criterion": {"type": "inventory_contains", "item": "bucket", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "iron_ingot", "count": 3}, {"item": "crafting_table", "count": 1}]
+      },
+      "source_refs": [{"kind": "MineStudio", "task": "craft_to_cake", "difficulty": "simple"}, {"kind": "TechTree", "tier": "Iron"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "craft_to_cake uses buckets as prerequisites; this isolates bucket crafting."
+      }
+    },
+    {
+      "id": "iron.craft_shears",
+      "tier": "Iron",
+      "family": "crafting_inventory",
+      "title": "Craft shears",
+      "target_item": "shears",
+      "success_criterion": {"type": "inventory_contains", "item": "shears", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "iron_ingot", "count": 2}]
+      },
+      "source_refs": [{"kind": "MineStudio", "task": "collect_wool", "difficulty": "simple"}, {"kind": "TechTree", "tier": "Iron"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "Shearing wool is excluded; shears crafting itself is deterministic and inventory-scored."
+      }
+    },
+    {
+      "id": "gold_redstone.obtain_raw_gold",
+      "tier": "Gold-Redstone",
+      "family": "dig_pickup",
+      "title": "Obtain raw gold",
+      "target_item": "raw_gold",
+      "success_criterion": {"type": "inventory_contains", "item": "raw_gold", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "iron_pickaxe", "count": 1}],
+        "blocks": [{"block": "gold_ore", "relative": [2, 0, 0]}]
+      },
+      "source_refs": [{"kind": "TechTree", "tier": "Gold-Redstone"}, {"kind": "MineStudio", "task": "craft_to_clock", "difficulty": "simple"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "No exact MineStudio gold mining task exists; included as standard tech-tree ore step."
+      }
+    },
+    {
+      "id": "gold_redstone.smelt_gold_ingot",
+      "tier": "Gold-Redstone",
+      "family": "smelting",
+      "title": "Smelt gold ingot",
+      "target_item": "gold_ingot",
+      "success_criterion": {"type": "inventory_contains", "item": "gold_ingot", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "raw_gold", "count": 1}, {"item": "coal", "count": 1}, {"item": "furnace", "count": 1}]
+      },
+      "source_refs": [{"kind": "MineStudio", "task": "craft_to_clock", "difficulty": "simple"}, {"kind": "TechTree", "tier": "Gold-Redstone"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "Standard ore smelting step before clock crafting."
+      }
+    },
+    {
+      "id": "gold_redstone.obtain_redstone",
+      "tier": "Gold-Redstone",
+      "family": "dig_pickup",
+      "title": "Obtain redstone",
+      "target_item": "redstone",
+      "success_criterion": {"type": "inventory_contains", "item": "redstone", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "iron_pickaxe", "count": 1}],
+        "blocks": [{"block": "redstone_ore", "relative": [2, 0, 0]}]
+      },
+      "source_refs": [{"kind": "MineStudio", "task": "craft_to_clock", "difficulty": "simple"}, {"kind": "TechTree", "tier": "Gold-Redstone"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "No exact redstone mining YAML exists; redstone is used by MineStudio clock task."
+      }
+    },
+    {
+      "id": "gold_redstone.craft_clock",
+      "tier": "Gold-Redstone",
+      "family": "crafting_table",
+      "title": "Craft clock",
+      "target_item": "clock",
+      "success_criterion": {"type": "inventory_contains", "item": "clock", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "gold_ingot", "count": 4}, {"item": "redstone", "count": 1}, {"item": "crafting_table", "count": 1}]
+      },
+      "source_refs": [{"kind": "MineStudio", "task": "craft_to_clock", "difficulty": "simple"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "MineStudio craft_to_clock pre-gives ingredients, not clock."
+      }
+    },
+    {
+      "id": "gold_redstone.craft_compass",
+      "tier": "Gold-Redstone",
+      "family": "crafting_table",
+      "title": "Craft compass",
+      "target_item": "compass",
+      "success_criterion": {"type": "inventory_contains", "item": "compass", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "iron_ingot", "count": 4}, {"item": "redstone", "count": 1}, {"item": "crafting_table", "count": 1}]
+      },
+      "source_refs": [{"kind": "MineStudio", "task": "find_village", "difficulty": "simple"}, {"kind": "TechTree", "tier": "Gold-Redstone"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "MineStudio exploration tasks use compass as an item; this isolates the standard recipe."
+      }
+    },
+    {
+      "id": "diamond.obtain_diamond",
+      "tier": "Diamond",
+      "family": "dig_pickup",
+      "title": "Obtain diamond",
+      "target_item": "diamond",
+      "success_criterion": {"type": "inventory_contains", "item": "diamond", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "iron_pickaxe", "count": 1}],
+        "blocks": [{"block": "diamond_ore", "relative": [2, -1, 0]}]
+      },
+      "source_refs": [{"kind": "MineStudio", "task": "find_diamond", "difficulty": "simple"}, {"kind": "MineStudio", "task": "mine_diamond_ore", "difficulty": "simple"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "Diamond ore mined with iron pickaxe yields diamond."
+      }
+    },
+    {
+      "id": "diamond.obtain_obsidian",
+      "tier": "Diamond",
+      "family": "dig_pickup",
+      "title": "Obtain obsidian",
+      "target_item": "obsidian",
+      "success_criterion": {"type": "inventory_contains", "item": "obsidian", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "diamond_pickaxe", "count": 1}],
+        "blocks": [{"block": "obsidian", "relative": [2, 0, 0]}]
+      },
+      "source_refs": [{"kind": "MineStudio", "task": "mine_obsidian", "difficulty": "simple"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "Obsidian requires diamond pickaxe; target is not pre-given."
+      }
+    },
+    {
+      "id": "diamond.craft_diamond_pickaxe",
+      "tier": "Diamond",
+      "family": "crafting_table",
+      "title": "Craft diamond pickaxe",
+      "target_item": "diamond_pickaxe",
+      "success_criterion": {"type": "inventory_contains", "item": "diamond_pickaxe", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "diamond", "count": 3}, {"item": "stick", "count": 2}, {"item": "crafting_table", "count": 1}]
+      },
+      "source_refs": [{"kind": "MineStudio", "task": "mine_obsidian", "difficulty": "simple"}, {"kind": "TechTree", "tier": "Diamond"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "Standard diamond tool milestone."
+      }
+    },
+    {
+      "id": "diamond.craft_enchanting_table",
+      "tier": "Diamond",
+      "family": "crafting_table",
+      "title": "Craft enchanting table",
+      "target_item": "enchanting_table",
+      "success_criterion": {"type": "inventory_contains", "item": "enchanting_table", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "obsidian", "count": 4}, {"item": "diamond", "count": 2}, {"item": "book", "count": 1}, {"item": "crafting_table", "count": 1}]
+      },
+      "source_refs": [{"kind": "MineStudio", "task": "craft_enchantment", "difficulty": "simple"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "MineStudio craft_enchantment gives ingredients, not enchanting_table."
+      }
+    },
+    {
+      "id": "armor.craft_iron_helmet",
+      "tier": "Armor",
+      "family": "crafting_table",
+      "title": "Craft iron helmet",
+      "target_item": "iron_helmet",
+      "success_criterion": {"type": "inventory_contains", "item": "iron_helmet", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "iron_ingot", "count": 5}, {"item": "crafting_table", "count": 1}]
+      },
+      "source_refs": [{"kind": "TechTree", "tier": "Armor"}, {"kind": "MineStudio", "task": "survive_combat", "difficulty": "simple"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "Armor crafting isolated from combat tasks."
+      }
+    },
+    {
+      "id": "armor.craft_iron_chestplate",
+      "tier": "Armor",
+      "family": "crafting_table",
+      "title": "Craft iron chestplate",
+      "target_item": "iron_chestplate",
+      "success_criterion": {"type": "inventory_contains", "item": "iron_chestplate", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "iron_ingot", "count": 8}, {"item": "crafting_table", "count": 1}]
+      },
+      "source_refs": [{"kind": "TechTree", "tier": "Armor"}, {"kind": "MineStudio", "task": "survive_combat", "difficulty": "hard"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "Inventory-scored armor milestone."
+      }
+    },
+    {
+      "id": "armor.craft_diamond_helmet",
+      "tier": "Armor",
+      "family": "crafting_table",
+      "title": "Craft diamond helmet",
+      "target_item": "diamond_helmet",
+      "success_criterion": {"type": "inventory_contains", "item": "diamond_helmet", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "diamond", "count": 5}, {"item": "crafting_table", "count": 1}]
+      },
+      "source_refs": [{"kind": "TechTree", "tier": "Armor"}, {"kind": "MineStudio", "task": "enchant_diamond_sword", "difficulty": "simple"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "Diamond armor milestone; source task demonstrates diamond equipment tier."
+      }
+    },
+    {
+      "id": "armor.craft_diamond_chestplate",
+      "tier": "Armor",
+      "family": "crafting_table",
+      "title": "Craft diamond chestplate",
+      "target_item": "diamond_chestplate",
+      "success_criterion": {"type": "inventory_contains", "item": "diamond_chestplate", "count": 1},
+      "setup": {
+        "clear_inventory": true,
+        "inventory": [{"item": "diamond", "count": 8}, {"item": "crafting_table", "count": 1}]
+      },
+      "source_refs": [{"kind": "TechTree", "tier": "Armor"}, {"kind": "MineStudio", "task": "enchant_diamond_sword", "difficulty": "hard"}],
+      "vetting": {
+        "target_item_correct": true,
+        "non_degenerate_setup": true,
+        "mineflayer_executable": true,
+        "programmatic_scorable": true,
+        "notes": "Diamond armor milestone; no target item is pre-given."
+      }
+    }
+  ],
+  "excluded_source_groups": [
+    {
+      "reason": "reset_already_contains_or_directly_gives_target_item",
+      "tasks": ["collect_dirt", "craft_the_crafting_table", "tool_lead", "tool_trident"],
+      "notes": "These are unsuitable as direct obtain-item tasks when the desired item is already present after setup."
+    },
+    {
+      "reason": "drop_or_mechanic_ambiguous_for_inventory_target",
+      "tasks": ["mine_grass", "tool_flint", "tool_pumpkin"],
+      "notes": "Examples include grass blocks mined without silk touch or chance-based gravel-to-flint behavior."
+    },
+    {
+      "reason": "entity_or_combat_goal_not_inventory_techtree",
+      "tasks": [
+        "collect_seagrass",
+        "collect_wool",
+        "combat_enderman",
+        "combat_enemies",
+        "combat_skeletons",
+        "combat_spider",
+        "combat_spiders",
+        "combat_zombies",
+        "hunt_a_sheep",
+        "hunt_animals",
+        "lead_animals",
+        "shoot_phantom",
+        "survive_combat",
+        "survive_hunt",
+        "survive_shield",
+        "use_bow",
+        "use_shield",
+        "use_trident"
+      ],
+      "notes": "These require entity state, combat outcome, shearing, leading, or projectile hit criteria rather than pure obtain-item scoring."
+    },
+    {
+      "reason": "exploration_or_navigation_goal_not_programmatic_item_success",
+      "tasks": [
+        "clean_up",
+        "climb_the_mountain",
+        "explore_boat",
+        "explore_chest",
+        "explore_climb",
+        "explore_mine",
+        "explore_run",
+        "explore_the_treasure",
+        "find_forest",
+        "find_village",
+        "run_and_explore",
+        "travel_by_boat"
+      ],
+      "notes": "These are useful scenarios but not clean inventory/state obtain-item benchmark tasks."
+    },
+    {
+      "reason": "structure_or_world_edit_goal_not_obtain_item",
+      "tasks": [
+        "build_a_waterfall",
+        "build_dig3fill1",
+        "build_gate",
+        "build_golems",
+        "build_nether_portal",
+        "build_obsidian",
+        "build_pillar",
+        "build_snow_golem",
+        "dig_three_down_and_fill_one_up",
+        "make_fire_with_flint_and_steel",
+        "make_obsidian_by_wate",
+        "mine_horizontally",
+        "plant_wheats",
+        "prepare_a_birthday_present_for_your_neighbor",
+        "set_fires",
+        "sleep_in_bed",
+        "survive_plant",
+        "survive_sleep"
+      ],
+      "notes": "These are place/use/world-state scenarios. They may become a separate state benchmark, but they are not part of this obtain-item tech-tree manifest."
+    },
+    {
+      "reason": "gui_or_special_system_state_not_inventory_item",
+      "tasks": ["carve_pumpkins", "drink_harming_potion", "enchant_diamond_sword", "enchant_sword", "smelt_food"],
+      "notes": "These need potion effects, enchantment metadata, carved block state, or food-specific outputs; kept out of the clean v1 manifest."
+    },
+    {
+      "reason": "included_as_related_source_but_not_as_original_task_id",
+      "tasks": [
+        "collect_grass",
+        "collect_wood",
+        "craft_enchantment",
+        "craft_ladder",
+        "craft_smelting",
+        "craft_stonecut",
+        "craft_table",
+        "craft_to_clock",
+        "craft_to_ladder",
+        "cut_stone",
+        "find_diamond",
+        "mine_diamond_ore",
+        "mine_dirt",
+        "mine_iron_ore",
+        "mine_obsidian",
+        "tool_bow"
+      ],
+      "notes": "The new PR-ready task ids are normalized tech-tree ids; these MineStudio names are preserved in source_refs."
+    }
+  ],
+  "phase1_summary": {
+    "active_task_count": 40,
+    "tiers": ["Wooden", "Stone", "Iron", "Gold-Redstone", "Diamond", "Armor"],
+    "families": ["dig_pickup", "crafting_inventory", "crafting_table", "smelting"],
+    "requires_llm": false,
+    "requires_minecraft_server_for_manifest_validation": false,
+    "agent_execution_in_phase1": false
+  }
+}

--- a/PhyAgentOS/benchmarks/minecraft/techtree/schema.py
+++ b/PhyAgentOS/benchmarks/minecraft/techtree/schema.py
@@ -1,0 +1,215 @@
+"""Data structures for the executor-independent Minecraft tech-tree benchmark."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+JsonDict = dict[str, Any]
+
+DEFAULT_ARENA_ORIGIN = (-2000, 80, -2000)
+DEFAULT_ARENA_CLEAR_RADIUS = 8
+DEFAULT_ARENA_CLEAR_HEIGHT = 6
+DEFAULT_ARENA_FLOOR_BLOCK = "smooth_stone"
+DEFAULT_ARENA_BOUNDARY_BLOCK = "stone_bricks"
+
+
+@dataclass(frozen=True)
+class SetupItem:
+    item: str
+    count: int = 1
+    enchantments: tuple[JsonDict, ...] = ()
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "SetupItem":
+        return cls(
+            item=str(data["item"]),
+            count=int(data.get("count", 1) or 1),
+            enchantments=tuple(dict(entry) for entry in data.get("enchantments", []) or []),
+        )
+
+    def to_dict(self) -> JsonDict:
+        payload: JsonDict = {"item": self.item, "count": self.count}
+        if self.enchantments:
+            payload["enchantments"] = [dict(entry) for entry in self.enchantments]
+        return payload
+
+
+@dataclass(frozen=True)
+class SetupBlock:
+    block: str
+    relative: tuple[int, int, int]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "SetupBlock":
+        relative = data.get("relative")
+        if not isinstance(relative, list | tuple) or len(relative) != 3:
+            raise ValueError(f"setup block requires relative [x,y,z]: {data!r}")
+        return cls(
+            block=str(data["block"]),
+            relative=(int(relative[0]), int(relative[1]), int(relative[2])),
+        )
+
+    def to_dict(self) -> JsonDict:
+        return {"block": self.block, "relative": list(self.relative)}
+
+
+@dataclass(frozen=True)
+class ArenaSetup:
+    enabled: bool = True
+    origin: tuple[int, int, int] = DEFAULT_ARENA_ORIGIN
+    clear_radius: int = DEFAULT_ARENA_CLEAR_RADIUS
+    clear_height: int = DEFAULT_ARENA_CLEAR_HEIGHT
+    floor_block: str = DEFAULT_ARENA_FLOOR_BLOCK
+    boundary_block: str = DEFAULT_ARENA_BOUNDARY_BLOCK
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> "ArenaSetup":
+        data = dict(data or {})
+        origin = data.get("origin", DEFAULT_ARENA_ORIGIN)
+        if not isinstance(origin, list | tuple) or len(origin) != 3:
+            raise ValueError(f"arena origin must be [x,y,z]: {data!r}")
+        return cls(
+            enabled=bool(data.get("enabled", True)),
+            origin=(int(origin[0]), int(origin[1]), int(origin[2])),
+            clear_radius=max(1, int(data.get("clear_radius", DEFAULT_ARENA_CLEAR_RADIUS) or DEFAULT_ARENA_CLEAR_RADIUS)),
+            clear_height=max(1, int(data.get("clear_height", DEFAULT_ARENA_CLEAR_HEIGHT) or DEFAULT_ARENA_CLEAR_HEIGHT)),
+            floor_block=str(data.get("floor_block") or DEFAULT_ARENA_FLOOR_BLOCK),
+            boundary_block=str(data.get("boundary_block") or DEFAULT_ARENA_BOUNDARY_BLOCK),
+        )
+
+    def to_dict(self) -> JsonDict:
+        return {
+            "enabled": self.enabled,
+            "origin": list(self.origin),
+            "clear_radius": self.clear_radius,
+            "clear_height": self.clear_height,
+            "floor_block": self.floor_block,
+            "boundary_block": self.boundary_block,
+        }
+
+
+@dataclass(frozen=True)
+class WorldSetup:
+    clear_inventory: bool = True
+    arena: ArenaSetup = field(default_factory=ArenaSetup)
+    inventory: tuple[SetupItem, ...] = ()
+    blocks: tuple[SetupBlock, ...] = ()
+    raw: JsonDict = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> "WorldSetup":
+        data = dict(data or {})
+        return cls(
+            clear_inventory=bool(data.get("clear_inventory", True)),
+            arena=ArenaSetup.from_dict(data.get("arena")),
+            inventory=tuple(SetupItem.from_dict(entry) for entry in data.get("inventory", []) or []),
+            blocks=tuple(SetupBlock.from_dict(entry) for entry in data.get("blocks", []) or []),
+            raw=data,
+        )
+
+    def to_dict(self) -> JsonDict:
+        payload = dict(self.raw)
+        payload["clear_inventory"] = self.clear_inventory
+        payload["arena"] = self.arena.to_dict()
+        payload["inventory"] = [item.to_dict() for item in self.inventory]
+        payload["blocks"] = [block.to_dict() for block in self.blocks]
+        return payload
+
+
+@dataclass(frozen=True)
+class SuccessCriterion:
+    type: str
+    item: str | None = None
+    count: int = 1
+    raw: JsonDict = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "SuccessCriterion":
+        return cls(
+            type=str(data["type"]),
+            item=str(data["item"]) if data.get("item") is not None else None,
+            count=int(data.get("count", 1) or 1),
+            raw=dict(data),
+        )
+
+    def to_dict(self) -> JsonDict:
+        payload = dict(self.raw)
+        payload["type"] = self.type
+        if self.item is not None:
+            payload["item"] = self.item
+        payload["count"] = self.count
+        return payload
+
+
+@dataclass(frozen=True)
+class TechTreeTask:
+    id: str
+    tier: str
+    family: str
+    title: str
+    target_item: str
+    success_criterion: SuccessCriterion
+    setup: WorldSetup
+    source_refs: tuple[JsonDict, ...] = ()
+    vetting: JsonDict = field(default_factory=dict)
+    raw: JsonDict = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "TechTreeTask":
+        return cls(
+            id=str(data["id"]),
+            tier=str(data["tier"]),
+            family=str(data["family"]),
+            title=str(data.get("title") or data["id"]),
+            target_item=str(data["target_item"]),
+            success_criterion=SuccessCriterion.from_dict(data["success_criterion"]),
+            setup=WorldSetup.from_dict(data.get("setup")),
+            source_refs=tuple(dict(entry) for entry in data.get("source_refs", []) or []),
+            vetting=dict(data.get("vetting") or {}),
+            raw=dict(data),
+        )
+
+    def to_dict(self) -> JsonDict:
+        payload = dict(self.raw)
+        payload.update(
+            {
+                "id": self.id,
+                "tier": self.tier,
+                "family": self.family,
+                "title": self.title,
+                "target_item": self.target_item,
+                "success_criterion": self.success_criterion.to_dict(),
+                "setup": self.setup.to_dict(),
+                "source_refs": [dict(entry) for entry in self.source_refs],
+                "vetting": dict(self.vetting),
+            }
+        )
+        return payload
+
+
+@dataclass(frozen=True)
+class TaskManifest:
+    version: str
+    name: str
+    tasks: tuple[TechTreeTask, ...]
+    raw: JsonDict = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "TaskManifest":
+        return cls(
+            version=str(data["version"]),
+            name=str(data["name"]),
+            tasks=tuple(TechTreeTask.from_dict(entry) for entry in data.get("tasks", []) or []),
+            raw=dict(data),
+        )
+
+    def task_map(self) -> dict[str, TechTreeTask]:
+        return {task.id: task for task in self.tasks}
+
+    def to_dict(self) -> JsonDict:
+        payload = dict(self.raw)
+        payload["version"] = self.version
+        payload["name"] = self.name
+        payload["tasks"] = [task.to_dict() for task in self.tasks]
+        return payload

--- a/docs/scenarios/game/minecraft/techtree_benchmark.md
+++ b/docs/scenarios/game/minecraft/techtree_benchmark.md
@@ -1,0 +1,296 @@
+# PhyAgentOS x Minecraft - Tech-Tree Benchmark
+
+> Reading Path: Minecraft benchmark integration.
+> This page documents the executor-independent Minecraft tech-tree benchmark
+> and how it fits into the PhyAgentOS target, skillruntime, session, and
+> watchdog model.
+
+---
+
+## Status
+
+| Component | Status | Notes |
+|---|---|---|
+| Vetted manifest | Ready | 40 obtain-item tasks across six tiers |
+| Programmatic evaluator | Ready | Inventory/state checks, no LLM or VLM judge |
+| Executor-independent harness | Ready | Agent and world adapter are injected |
+| Mineflayer bridge adapter | Example | Optional reference adapter, not core dependency |
+| OS session runner integration | External wrapper | Use `TARGETS.md`, `SKILLRUNTIME.md`, `SESSIONS.md`, and watchdog outside the benchmark core |
+
+---
+
+## What This Benchmark Is
+
+The tech-tree benchmark measures whether an agent can obtain standard Minecraft
+items along a progression path:
+
+```
+Wooden -> Stone -> Iron -> Gold/Redstone -> Diamond -> Armor
+```
+
+Each task has:
+
+- a stable task id, such as `wooden.obtain_oak_log`;
+- a tier and family;
+- a deterministic setup description;
+- a `target_item`;
+- a programmatic success criterion.
+
+The task set is derived from and vetted against MineStudio-style task configs
+and common Minecraft tech-tree milestones, but it is a standalone PhyAgentOS
+reimplementation.  It is not the official MineStudio, MCU, MineEvolve,
+TeamCraft, or VPT benchmark protocol.
+
+The benchmark is intentionally narrow.  It is an execution-layer benchmark:
+reference-adapter tasks run in an isolated arena, place required materials or
+target blocks near the agent, expose target coordinates through setup, and give
+prerequisite tools declared by the task.  It measures whether an agent can carry
+out low-level Minecraft actions, including local navigation, digging, pickup,
+crafting, placing, and smelting, once the target is localized and prerequisites
+are staged.
+
+It does not measure open-world exploration, resource search, visual target
+localization, high-level planning, long-horizon reasoning, multi-agent
+coordination, or true tech-tree dependency climbing.  The tiers are difficulty
+and category labels, not a dependency chain that the agent must discover or
+execute across tasks.
+
+---
+
+## Architecture
+
+```
+manifest.json
+  -> loader.py
+      -> TechTreeTask
+          -> world_adapter.reset(task.setup)
+          -> injected agent_fn(task, world_adapter)
+          -> world_adapter.observe()
+          -> evaluator.py
+              -> BenchmarkResult
+```
+
+The benchmark core does not import PhyAgentOS session or agent machinery.  It
+can be wrapped by OS sessions, a direct script, a policy runner, or another
+project's Minecraft controller.
+
+---
+
+## Relation To PhyAgentOS Runtime Files
+
+The benchmark itself is lower-level than `SESSIONS.md`.
+
+| Layer | Responsibility |
+|---|---|
+| `TARGETS.md` | Declares the Minecraft target and bridge endpoint |
+| `SKILLRUNTIME.md` | Declares which runtime can execute sessions |
+| `SESSIONS.md` | Queues a concrete benchmark episode for watchdog execution |
+| WatchdogSupervisor | Claims the session and runs the selected runtime |
+| `minecraft_techtree` benchmark | Defines setup, task metadata, and deterministic scoring |
+
+An OS-native benchmark wrapper should create sessions that reference this
+benchmark in `runtime_hints`, but the `minecraft_techtree` package itself should
+remain independent of watchdog and session schemas.
+
+---
+
+## Public API
+
+```python
+from PhyAgentOS.benchmarks.minecraft.techtree import (
+    evaluate_task,
+    list_tasks,
+    load_task,
+    run_task,
+)
+
+task = load_task("stone.craft_furnace")
+print(task.target_item)
+
+verdict = evaluate_task(task, {"inventory": {"furnace": 1}})
+print(verdict.success)
+```
+
+To run with an arbitrary agent:
+
+```python
+def agent_fn(task, world):
+    # Any implementation is allowed here: LLM, scripted agent, policy, etc.
+    return {"ok": True}
+
+
+result = run_task("wooden.obtain_oak_log", agent_fn, world_adapter)
+print(result.success, result.reward)
+```
+
+The world adapter interface is deliberately small:
+
+```python
+class WorldAdapter:
+    def reset(self, setup):
+        ...
+
+    def observe(self):
+        ...
+```
+
+---
+
+## Optional Mineflayer Bridge Adapter
+
+The package includes an example adapter:
+
+```python
+from PhyAgentOS.benchmarks.minecraft.techtree.adapters.mineflayer_bridge import (
+    MineflayerBridgeAdapter,
+)
+
+world = MineflayerBridgeAdapter("http://127.0.0.1:3000")
+```
+
+It uses the bridge `/phase`, `/action`, and `/state` endpoints to perform setup
+and observation.  It is not imported by `loader.py`, `evaluator.py`, or
+`harness.py`.
+
+The reference adapter also provides bounded scene isolation.  During reset it
+teleports the bot to a fixed arena origin, clears a bounded box, lays a fixed
+floor, marks the boundary, and places task blocks at coordinates relative to the
+arena origin.  This avoids reusing arbitrary old terrain near the bot while
+keeping the core benchmark adapter-agnostic.
+
+---
+
+## Task Tiers
+
+| Tier | Count | Examples |
+|---|---:|---|
+| Wooden | 10 | `wooden.obtain_oak_log`, `wooden.craft_crafting_table` |
+| Stone | 8 | `stone.obtain_cobblestone`, `stone.craft_furnace` |
+| Iron | 9 | `iron.obtain_raw_iron`, `iron.smelt_iron_ingot` |
+| Gold-Redstone | 5 | `gold_redstone.obtain_redstone`, `gold_redstone.craft_clock` |
+| Diamond | 4 | `diamond.obtain_diamond`, `diamond.craft_enchanting_table` |
+| Armor | 4 | `armor.craft_iron_chestplate`, `armor.craft_diamond_chestplate` |
+
+Task families:
+
+| Family | Count | Scoring |
+|---|---:|---|
+| `dig_pickup` | 10 | Inventory contains the dropped target item |
+| `crafting_inventory` | 5 | Inventory contains crafted item |
+| `crafting_table` | 23 | Inventory contains crafted item |
+| `smelting` | 2 | Inventory contains smelted item |
+
+The complete task list lives in:
+
+```text
+PhyAgentOS/benchmarks/minecraft/techtree/manifest.json
+```
+
+---
+
+## Task Table
+
+### Wooden
+
+| id | target_item | family |
+|---|---|---|
+| `wooden.obtain_oak_log` | `oak_log` | `dig_pickup` |
+| `wooden.obtain_dirt` | `dirt` | `dig_pickup` |
+| `wooden.obtain_grass_block` | `grass_block` | `dig_pickup` |
+| `wooden.craft_oak_planks` | `oak_planks` | `crafting_inventory` |
+| `wooden.craft_stick` | `stick` | `crafting_inventory` |
+| `wooden.craft_crafting_table` | `crafting_table` | `crafting_inventory` |
+| `wooden.craft_chest` | `chest` | `crafting_table` |
+| `wooden.craft_ladder` | `ladder` | `crafting_table` |
+| `wooden.craft_bow` | `bow` | `crafting_table` |
+| `wooden.craft_wooden_pickaxe` | `wooden_pickaxe` | `crafting_table` |
+
+### Stone
+
+| id | target_item | family |
+|---|---|---|
+| `stone.obtain_cobblestone` | `cobblestone` | `dig_pickup` |
+| `stone.craft_stone_pickaxe` | `stone_pickaxe` | `crafting_table` |
+| `stone.craft_stone_axe` | `stone_axe` | `crafting_table` |
+| `stone.craft_stone_shovel` | `stone_shovel` | `crafting_table` |
+| `stone.craft_stone_sword` | `stone_sword` | `crafting_table` |
+| `stone.craft_furnace` | `furnace` | `crafting_table` |
+| `stone.craft_stonecutter` | `stonecutter` | `crafting_table` |
+| `stone.craft_torch` | `torch` | `crafting_inventory` |
+
+### Iron
+
+| id | target_item | family |
+|---|---|---|
+| `iron.obtain_coal` | `coal` | `dig_pickup` |
+| `iron.obtain_raw_iron` | `raw_iron` | `dig_pickup` |
+| `iron.smelt_iron_ingot` | `iron_ingot` | `smelting` |
+| `iron.craft_iron_pickaxe` | `iron_pickaxe` | `crafting_table` |
+| `iron.craft_iron_axe` | `iron_axe` | `crafting_table` |
+| `iron.craft_iron_shovel` | `iron_shovel` | `crafting_table` |
+| `iron.craft_iron_sword` | `iron_sword` | `crafting_table` |
+| `iron.craft_bucket` | `bucket` | `crafting_table` |
+| `iron.craft_shears` | `shears` | `crafting_inventory` |
+
+### Gold-Redstone
+
+| id | target_item | family |
+|---|---|---|
+| `gold_redstone.obtain_raw_gold` | `raw_gold` | `dig_pickup` |
+| `gold_redstone.smelt_gold_ingot` | `gold_ingot` | `smelting` |
+| `gold_redstone.obtain_redstone` | `redstone` | `dig_pickup` |
+| `gold_redstone.craft_clock` | `clock` | `crafting_table` |
+| `gold_redstone.craft_compass` | `compass` | `crafting_table` |
+
+### Diamond
+
+| id | target_item | family |
+|---|---|---|
+| `diamond.obtain_diamond` | `diamond` | `dig_pickup` |
+| `diamond.obtain_obsidian` | `obsidian` | `dig_pickup` |
+| `diamond.craft_diamond_pickaxe` | `diamond_pickaxe` | `crafting_table` |
+| `diamond.craft_enchanting_table` | `enchanting_table` | `crafting_table` |
+
+### Armor
+
+| id | target_item | family |
+|---|---|---|
+| `armor.craft_iron_helmet` | `iron_helmet` | `crafting_table` |
+| `armor.craft_iron_chestplate` | `iron_chestplate` | `crafting_table` |
+| `armor.craft_diamond_helmet` | `diamond_helmet` | `crafting_table` |
+| `armor.craft_diamond_chestplate` | `diamond_chestplate` | `crafting_table` |
+
+---
+
+## Reporting Guidance
+
+Reports should include:
+
+- benchmark name and manifest version;
+- task ids and tier split;
+- agent or runtime used;
+- world adapter used;
+- number of repetitions per task;
+- success rate and mean reward;
+- failure categories when available;
+- reproducibility notes, including Minecraft version, bridge version, and setup.
+
+Do not compare these numbers directly to MineStudio, MCU, MineEvolve, TeamCraft,
+or VPT leaderboards.  This benchmark is a vetted, executor-independent,
+standalone obtain-item reimplementation designed for OS integration and
+repeatable programmatic scoring.
+
+---
+
+## Limitations
+
+| Limitation | Impact |
+|---|---|
+| Standalone vetted subset | Derived from MineStudio-style configs and tech-tree tiers, then reimplemented as a standalone programmatic mineflayer benchmark; not an official MineStudio, MCU, MineEvolve, TeamCraft, or VPT protocol, so scores are not comparable to their public numbers |
+| Execution-layer scope | Materials or target blocks are placed near the agent, target coordinates are available through setup, and prerequisite tools are provided; scores measure low-level physical execution after setup |
+| Not an exploration or planning benchmark | Does not measure resource search, visual target localization, high-level planning, long-horizon reasoning, or true tech-tree dependency climbing |
+| Tech-tree tiers are labels | Tiers describe task category and difficulty; tasks are isolated and do not require the agent to traverse a dependency chain across tasks |
+| Programmatic inventory/state scoring | Avoids VLM judgment but misses visual or semantic nuance |
+| Arena-only scene isolation | Reference adapter uses a fixed cleaned arena and relative task placement; it does not regenerate full world seeds or natural terrain |
+| Execution non-determinism | Use repeated trials when reporting results |
+| Reference adapter is mineflayer-specific | Core benchmark remains adapter-agnostic |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,8 @@ packages = ["PhyAgentOS"]
 [tool.hatch.build]
 include = [
     "PhyAgentOS/**/*.py",
+    "PhyAgentOS/benchmarks/**/*.json",
+    "PhyAgentOS/benchmarks/**/*.md",
     "PhyAgentOS/templates/**/*.md",
     "PhyAgentOS/templates/**/*.json",
     "PhyAgentOS/templates/**/*.yaml",

--- a/tests/test_minecraft_techtree_benchmark.py
+++ b/tests/test_minecraft_techtree_benchmark.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from typing import Any
+
+from PhyAgentOS.benchmarks.minecraft.techtree import (
+    DEFAULT_ARENA_BOUNDARY_BLOCK,
+    DEFAULT_ARENA_CLEAR_HEIGHT,
+    DEFAULT_ARENA_CLEAR_RADIUS,
+    DEFAULT_ARENA_FLOOR_BLOCK,
+    DEFAULT_ARENA_ORIGIN,
+    evaluate_task,
+    inventory_count,
+    inventory_counts,
+    list_tasks,
+    load_manifest,
+    load_task,
+    run_task,
+)
+from PhyAgentOS.benchmarks.minecraft.techtree.adapters.mineflayer_bridge import MineflayerBridgeAdapter
+from PhyAgentOS.benchmarks.minecraft.techtree.loader import DEFAULT_MANIFEST_PATH
+from PhyAgentOS.benchmarks.minecraft.techtree.schema import WorldSetup
+
+
+def test_manifest_is_vetted_and_non_degenerate() -> None:
+    manifest = load_manifest()
+    tasks = list(manifest.tasks)
+    assert manifest.name == "minecraft_techtree"
+    assert len(tasks) == 40
+    assert len({task.id for task in tasks}) == len(tasks)
+
+    allowed_tiers = {"Wooden", "Stone", "Iron", "Gold-Redstone", "Diamond", "Armor"}
+    allowed_families = {"dig_pickup", "crafting_inventory", "crafting_table", "smelting"}
+    for task in tasks:
+        assert task.tier in allowed_tiers
+        assert task.family in allowed_families
+        assert task.target_item
+        assert task.success_criterion.type == "inventory_contains"
+        assert task.success_criterion.item == task.target_item
+        assert task.success_criterion.count >= 1
+        assert task.target_item not in {item.item for item in task.setup.inventory}
+        assert task.setup.arena.enabled is True
+        assert task.setup.arena.origin == DEFAULT_ARENA_ORIGIN
+        assert task.vetting["target_item_correct"] is True
+        assert task.vetting["non_degenerate_setup"] is True
+        assert task.vetting["mineflayer_executable"] is True
+        assert task.vetting["programmatic_scorable"] is True
+
+
+def test_loader_filters_tasks_by_tier_and_family() -> None:
+    assert load_task("stone.craft_furnace").target_item == "furnace"
+
+    wooden_tasks = list_tasks(tier="Wooden")
+    assert len(wooden_tasks) == 10
+    assert {task.tier for task in wooden_tasks} == {"Wooden"}
+
+    smelting_tasks = list_tasks(family="smelting")
+    assert {task.id for task in smelting_tasks} == {
+        "iron.smelt_iron_ingot",
+        "gold_redstone.smelt_gold_ingot",
+    }
+
+
+def test_evaluator_accepts_common_inventory_shapes() -> None:
+    task = load_task("wooden.obtain_oak_log")
+
+    assert evaluate_task(task, {"inventory": {"oak_log": 1}}).success
+    assert evaluate_task(task, {"inventory": {"counts": {"oak_log": 1}}}).success
+    assert evaluate_task(task, {"inventory_items": [{"name": "minecraft:oak_log", "count": 1}]}).success
+    assert evaluate_task(task, {"info": {"inventory_items": [{"name": "oak_log", "count": 1}]}}).success
+    assert not evaluate_task(task, {"inventory": {"dirt": 1}}).success
+
+
+def test_evaluator_prefers_slot_item_list_over_summary_counts() -> None:
+    task = load_task("wooden.obtain_oak_log")
+    verdict = evaluate_task(
+        task,
+        {
+            "inventory_items": [{"name": "minecraft:oak_log", "count": 1}],
+            "inventory": {"oak_log": 99},
+        },
+    )
+
+    assert verdict.success
+    assert verdict.metrics["observed_count"] == 1
+    assert inventory_count({"info": {"inventory_items": [{"name": "minecraft:dirt", "count": 2}]}}, "dirt") == 2
+    assert inventory_counts({"inventory": [{"name": "minecraft:stick", "count": 4}]}) == {"stick": 4}
+
+
+class MockWorld:
+    def __init__(self) -> None:
+        self.inventory: dict[str, int] = {}
+        self.reset_setup: WorldSetup | None = None
+
+    def reset(self, setup: WorldSetup) -> dict[str, Any]:
+        self.reset_setup = setup
+        self.inventory = {item.item: item.count for item in setup.inventory}
+        return {"inventory": dict(self.inventory)}
+
+    def observe(self) -> dict[str, Any]:
+        return {"inventory": dict(self.inventory)}
+
+
+def test_harness_runs_injected_agent_and_world_adapter() -> None:
+    world = MockWorld()
+
+    def agent(task, adapter: MockWorld) -> dict[str, Any]:
+        adapter.inventory[task.target_item] = adapter.inventory.get(task.target_item, 0) + 1
+        return {"agent": "mock"}
+
+    result = run_task("wooden.obtain_oak_log", agent, world)
+
+    assert result.success
+    assert result.reward == 1.0
+    assert result.agent_result == {"agent": "mock"}
+    assert result.metadata["benchmark"] == "minecraft_techtree"
+    assert world.reset_setup is not None
+    assert result.verdict.metrics["observed_count"] == 1
+
+
+def test_harness_reports_agent_error_without_hiding_final_success() -> None:
+    world = MockWorld()
+
+    def agent(task, adapter: MockWorld) -> None:
+        adapter.inventory[task.target_item] = 1
+        raise RuntimeError("agent failed after acting")
+
+    result = run_task("wooden.obtain_oak_log", agent, world)
+
+    assert result.success
+    assert result.reward == 1.0
+    assert result.error == "RuntimeError: agent failed after acting"
+
+
+class RecordingBridgeAdapter(MineflayerBridgeAdapter):
+    def __init__(self) -> None:
+        super().__init__("http://example.invalid")
+        self.commands: list[str] = []
+        self.phases: list[tuple[str, bool]] = []
+
+    def _set_phase(self, phase: str, *, reset_counters: bool) -> None:
+        self.phases.append((phase, reset_counters))
+
+    def _command(self, command: str) -> dict[str, Any]:
+        self.commands.append(command)
+        return {"ok": True}
+
+    def observe(self) -> dict[str, Any]:
+        x, y, z = DEFAULT_ARENA_ORIGIN
+        return {"position": {"x": x, "y": y, "z": z}, "inventory": {}}
+
+
+def test_mineflayer_adapter_reset_builds_fixed_isolated_arena() -> None:
+    task = load_task("wooden.obtain_oak_log")
+    adapter = RecordingBridgeAdapter()
+
+    adapter.reset(task.setup)
+
+    x, y, z = DEFAULT_ARENA_ORIGIN
+    radius = DEFAULT_ARENA_CLEAR_RADIUS
+    height = DEFAULT_ARENA_CLEAR_HEIGHT
+    floor_y = y - 1
+    assert adapter.phases == [("reset", True), ("idle", False)]
+    assert adapter.commands[0] == f"/tp @s {x} {y} {z} 0 0"
+    assert adapter.commands[1] == (
+        f"/fill {x - radius} {y} {z - radius} {x + radius} {y + height} {z + radius} air"
+    )
+    assert adapter.commands[2] == (
+        f"/fill {x - radius} {floor_y} {z - radius} {x + radius} {floor_y} {z + radius} "
+        f"minecraft:{DEFAULT_ARENA_FLOOR_BLOCK}"
+    )
+    assert any(f"minecraft:{DEFAULT_ARENA_BOUNDARY_BLOCK}" in command for command in adapter.commands[3:7])
+    assert "/clear @s" in adapter.commands
+    assert "/give @s minecraft:wooden_axe 1" in adapter.commands
+    assert f"/setblock {x + 2} {y} {z} minecraft:oak_log" in adapter.commands
+
+
+def test_manifest_file_is_packaged_next_to_loader() -> None:
+    assert DEFAULT_MANIFEST_PATH.exists()
+    assert DEFAULT_MANIFEST_PATH.name == "manifest.json"
+    assert "external MineStudio" in load_manifest().raw["source_notes"]["self_contained_pr_policy"]


### PR DESCRIPTION
## Summary

Adds an executor-independent Minecraft tech-tree benchmark under `PhyAgentOS.benchmarks.minecraft.techtree`.

This benchmark is a standalone PhyAgentOS reimplementation of obtain-item
tech-tree tasks derived from and vetted against MineStudio-style task configs
and common Minecraft progression milestones. It is not the official MineStudio,
MCU, MineEvolve, TeamCraft, or VPT benchmark protocol, and scores should not be
compared to their public numbers.

It is an execution-layer benchmark. The reference adapter resets each task into
an isolated arena, places materials or target blocks near the agent, exposes
target coordinates through setup, and provides prerequisite tools. It measures
whether an injected agent can execute low-level Minecraft actions after setup;
it does not measure open-world exploration, resource search, visual target
localization, high-level planning, long-horizon reasoning, or true tech-tree
dependency climbing. The tech-tree tiers are task category and difficulty
labels, not a dependency chain the agent must traverse.

The benchmark provides:

- a vetted 40-task obtain-item manifest organized into six tech-tree tiers;
- deterministic inventory/state scoring;
- a small injected-agent harness (`run_task`) that is independent of any specific runtime, LLM, policy, or watchdog loop;
- an optional reference `MineflayerBridgeAdapter` for users who want to connect the benchmark to a mineflayer HTTP bridge, including fixed-arena setup isolation;
- no-LLM/no-server unit tests for the manifest, loader, evaluator, and harness.

This is a pure benchmark addition. It does not change existing runtime behavior, memory systems, skill induction, Hermes, or agent execution.

## Public API

```python
from PhyAgentOS.benchmarks.minecraft.techtree import (
    evaluate_task,
    list_tasks,
    load_task,
    run_task,
)

task = load_task("wooden.obtain_oak_log")
verdict = evaluate_task(task, {"inventory": {"oak_log": 1}})
print(verdict.success)
```

To evaluate an agent, users inject their own `agent_fn` and `world_adapter`:

```python
from PhyAgentOS.benchmarks.minecraft.techtree import run_task


def my_agent(task, world):
    # Scripted, LLM-driven, policy-driven, or any other executor.
    return {"ok": True}


result = run_task("wooden.obtain_oak_log", my_agent, my_world_adapter)
print(result.success, result.reward)
```

The benchmark core only expects the world adapter to implement:

```python
class WorldAdapter:
    def reset(self, setup):
        ...

    def observe(self):
        ...
```

## Task Coverage

The manifest contains 40 vetted obtain-item tasks across:

- Wooden
- Stone
- Iron
- Gold / Redstone
- Diamond
- Armor

Each task records its tier, task family, target item, setup, success criterion, and source task name. Scoring is currently deterministic and programmatic, primarily via `inventory_contains`.

The `source` fields are provenance hints for the vetting process, not claims
that this is an official reproduction of those external benchmark protocols.

## Design Notes

- Executor-independent: the benchmark does not import or call `minecraft_l0_react`, watchdog sessions, skill runtimes, governance, curator, induction, or workspace state.
- Deterministic scoring: success is computed from final observation inventory/state rather than LLM/VLM judgments.
- Adapter isolation: the optional mineflayer bridge adapter lives under `adapters/`; the core benchmark package remains independent of mineflayer and HTTP.
- Scene isolation: the reference adapter resets tasks into a fixed cleaned arena with relative task placement. This avoids stale local terrain but does not recreate a full world seed or natural terrain distribution.
- Packaging: `pyproject.toml` now includes benchmark JSON/Markdown package data.

## Documentation

Adds:

- `PhyAgentOS/benchmarks/minecraft/techtree/README.md`
- `docs/scenarios/game/minecraft/techtree_benchmark.md`

These document the API, task list, scoring model, adapter contract, and known limitations.

## Tests

```bash
pytest tests/test_minecraft_techtree_benchmark.py -q
```

Current result:

```text
7 passed
```

Also verified locally:

```bash
python -c "from PhyAgentOS.benchmarks.minecraft.techtree import list_tasks; print(len(list_tasks()))"
```

prints:

```text
40
```

## Limitations

- The tasks are derived from and vetted against MineStudio-style task configs, then reimplemented as a standalone programmatic mineflayer benchmark. This is not the official MineStudio, MCU, MineEvolve, TeamCraft, or VPT protocol, and scores should not be compared directly to their public numbers.
- This is an execution-layer obtain-item benchmark: materials or target blocks are staged near the agent, target coordinates are available through setup, and prerequisite tools are provided.
- It measures low-level physical execution after setup: local navigation, digging, pickup, crafting, placing, and smelting.
- It does not measure open-world exploration, resource search, visual target localization, high-level planning, long-horizon reasoning, or true tech-tree dependency climbing. The tech-tree tiers are category and difficulty labels, not a dependency chain the agent must traverse.
- Scoring is programmatic inventory/state checking, not VLM-based evaluation.
- The reference adapter provides fixed-arena isolation only; it does not reset or sample complete world seeds/terrain.
- Minecraft execution loops can be non-deterministic, so downstream evaluations should report repeated trials.
- Harder tiers may require substantial agent competence; the benchmark provides task definitions and scoring, not a guaranteed baseline policy.

## Relationship To Hermes / Self-Evolution

This benchmark is independent of the Hermes/self-evolution machinery. It does not replace or modify `3_self_evo.md`, memory, skill governance, or skill induction. It only provides a clean, reusable evaluation surface that those systems, or any external agent, can optionally plug into.
