### PR TITLE
add forge gateway runtime bridge

### DIFF
--- a/PhyAgentOS/runtime/gateway/__init__.py
+++ b/PhyAgentOS/runtime/gateway/__init__.py
@@ -1,0 +1,10 @@
+"""Forge Gateway MVP+ runtime bridge."""
+
+from PhyAgentOS.runtime.gateway.client import ForgeGatewayClient, ForgeGatewayError
+from PhyAgentOS.runtime.gateway.session_runner import GatewaySessionRunner
+
+__all__ = [
+    "ForgeGatewayClient",
+    "ForgeGatewayError",
+    "GatewaySessionRunner",
+]

--- a/PhyAgentOS/runtime/gateway/client.py
+++ b/PhyAgentOS/runtime/gateway/client.py
@@ -1,0 +1,66 @@
+"""HTTP client for Forge Gateway Agent-facing MVP+ APIs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+
+class ForgeGatewayError(RuntimeError):
+    """Raised when the Forge Gateway API rejects or fails a request."""
+
+
+class ForgeGatewayClient:
+    def __init__(self, base_url: str, *, timeout_s: float = 10.0):
+        self.base_url = base_url.rstrip("/")
+        self.timeout_s = max(0.1, float(timeout_s))
+
+    def capabilities(self) -> dict[str, Any]:
+        return self._get("/agent/runtime/capabilities")
+
+    def runtime_status(self) -> dict[str, Any]:
+        return self._get("/agent/runtime/status")
+
+    def runtime_context(self) -> dict[str, Any]:
+        return self._get("/agent/runtime/context")
+
+    def reset_runtime(self, inputs: dict[str, Any] | None = None) -> dict[str, Any]:
+        return self._post("/agent/runtime/reset", {"inputs": inputs or {}})
+
+    def create_session(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return self._post("/agent/sessions", payload)
+
+    def get_session(self, session_id: str) -> dict[str, Any]:
+        return self._get(f"/agent/sessions/{session_id}")
+
+    def cancel_session(self, session_id: str, reason: str = "paos_requested") -> dict[str, Any]:
+        return self._post(f"/agent/sessions/{session_id}/cancel", {"reason": reason})
+
+    def _get(self, path: str) -> dict[str, Any]:
+        try:
+            response = httpx.get(f"{self.base_url}{path}", timeout=self.timeout_s)
+        except httpx.HTTPError as exc:
+            raise ForgeGatewayError(f"Forge Gateway GET {path} failed: {exc}") from exc
+        return self._decode(response, path)
+
+    def _post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        try:
+            response = httpx.post(f"{self.base_url}{path}", json=payload, timeout=self.timeout_s)
+        except httpx.HTTPError as exc:
+            raise ForgeGatewayError(f"Forge Gateway POST {path} failed: {exc}") from exc
+        return self._decode(response, path)
+
+    def _decode(self, response: httpx.Response, path: str) -> dict[str, Any]:
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise ForgeGatewayError(
+                f"Forge Gateway {path} returned non-JSON response: HTTP {response.status_code}"
+            ) from exc
+        if response.status_code >= 400 or data.get("ok") is False:
+            message = data.get("msg") or data.get("message") or response.text
+            raise ForgeGatewayError(f"Forge Gateway {path} rejected request: {message}")
+        if not isinstance(data, dict):
+            raise ForgeGatewayError(f"Forge Gateway {path} returned invalid payload")
+        return data

--- a/PhyAgentOS/runtime/gateway/command_adapter.py
+++ b/PhyAgentOS/runtime/gateway/command_adapter.py
@@ -1,0 +1,92 @@
+"""Agent command adapter for direct Forge Gateway runtime commands."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from PhyAgentOS.runtime.gateway.client import ForgeGatewayClient
+from PhyAgentOS.runtime.state_io.markdown_yaml import read_yaml_block
+
+
+class ForgeGatewayCommandAdapter:
+    """Small Agent-facing adapter for commands that are not action sessions.
+
+    Phase-3 PAOS action execution still uses SESSIONS.md and GatewaySessionRunner.
+    Runtime-level commands such as scene reset should use this adapter so they do
+    not get misrepresented as `/agent/sessions` actions.
+    """
+
+    def __init__(self, client: ForgeGatewayClient):
+        self.client = client
+
+    @classmethod
+    def from_workspace(
+        cls,
+        workspace: str | Path,
+        *,
+        target_id: str = "forge_gateway",
+        timeout_s: float = 10.0,
+    ) -> "ForgeGatewayCommandAdapter":
+        endpoint = resolve_gateway_endpoint(Path(workspace), target_id=target_id)
+        return cls(ForgeGatewayClient(endpoint, timeout_s=timeout_s))
+
+    def reset_runtime(self, inputs: dict[str, Any] | None = None) -> dict[str, Any]:
+        return self.client.reset_runtime(inputs or {})
+
+
+def resolve_gateway_endpoint(workspace: Path, *, target_id: str = "forge_gateway") -> str:
+    targets_path = workspace.expanduser() / "TARGETS.md"
+    document = read_yaml_block(targets_path)
+    targets = document.get("targets")
+    if not isinstance(targets, list):
+        raise ValueError(f"{targets_path} must contain a targets list")
+
+    candidate_ids = [target_id]
+    if target_id == "forge_gateway":
+        # Existing workspaces created before the generic target rename may still
+        # use this legacy id. Keep reset usable without forcing users to rewrite
+        # their runtime workspace immediately.
+        candidate_ids.append("forge_gateway_piper_sim")
+
+    found_disabled: str | None = None
+    for target in targets:
+        if not isinstance(target, dict) or target.get("id") not in candidate_ids:
+            continue
+        if target.get("enabled") is not True:
+            found_disabled = str(target.get("id"))
+            continue
+        runtime = target.get("runtime") if isinstance(target.get("runtime"), dict) else {}
+        endpoint = runtime.get("target_endpoint")
+        if not isinstance(endpoint, str) or not endpoint:
+            raise ValueError(f"target {target.get('id')!r} does not define runtime.target_endpoint")
+        if not endpoint.startswith(("http://", "https://")):
+            raise ValueError(f"target {target.get('id')!r} endpoint must be HTTP(S): {endpoint}")
+        return endpoint
+
+    if found_disabled is not None:
+        raise ValueError(f"target {found_disabled!r} is not enabled in {targets_path}")
+    raise ValueError(f"target {target_id!r} not found in {targets_path}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Send direct Agent commands to Forge Gateway")
+    parser.add_argument("command", choices=["reset"], help="Command to execute")
+    parser.add_argument("--workspace", required=True, help="Runtime workspace containing TARGETS.md")
+    parser.add_argument("--target-id", default="forge_gateway", help="Gateway target id in TARGETS.md")
+    parser.add_argument("--reason", default="paos-agent", help="Reason attached to reset inputs")
+    args = parser.parse_args()
+
+    adapter = ForgeGatewayCommandAdapter.from_workspace(args.workspace, target_id=args.target_id)
+    if args.command == "reset":
+        response = adapter.reset_runtime({"reason": args.reason, "source": "paos-agent"})
+    else:
+        raise AssertionError(f"unsupported command: {args.command}")
+    print(json.dumps(response, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/PhyAgentOS/runtime/gateway/session_runner.py
+++ b/PhyAgentOS/runtime/gateway/session_runner.py
@@ -1,0 +1,159 @@
+"""Run one PAOS runtime session through Forge Gateway MVP+ APIs."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from PhyAgentOS.runtime.gateway.client import ForgeGatewayClient, ForgeGatewayError
+from PhyAgentOS.runtime.schemas import SessionResult, SessionSpec, SkillRuntimeSpec, TargetSpec
+
+_TERMINAL_GATEWAY_STATUSES = {"succeeded", "failed", "cancelled"}
+
+
+class GatewaySessionRunner:
+    """Bridge a PAOS SessionSpec to a single Forge Gateway action session.
+
+    This is the Phase-3 compatibility path for the existing watchdog +
+    SESSIONS.md queue. A future Agent command adapter should live beside this
+    module and call ForgeGatewayClient directly for capabilities, action
+    sessions, reset, cancel, and context without carrying PAOS target/runtime
+    execution fields through the bridge.
+    """
+
+    def __init__(
+        self,
+        *,
+        session: SessionSpec,
+        target_spec: TargetSpec,
+        skillruntime_spec: SkillRuntimeSpec,
+        client: ForgeGatewayClient | None = None,
+    ):
+        self.session = session
+        self.target_spec = target_spec
+        self.skillruntime_spec = skillruntime_spec
+        self.client = client or ForgeGatewayClient(
+            self._gateway_endpoint(),
+            timeout_s=max(1.0, float(session.timeouts.policy_timeout_s)),
+        )
+
+    def run(self) -> SessionResult:
+        payload = self._build_payload()
+        created = self.client.create_session(payload)
+        deadline = time.monotonic() + float(self.session.timeouts.execute_timeout_s)
+        poll_interval_s = self._poll_interval_s()
+        last_response = created
+
+        while True:
+            status = self._session_status(last_response)
+            if status in _TERMINAL_GATEWAY_STATUSES:
+                context = self._safe_runtime_context()
+                return self._to_result(status, last_response, context)
+            if time.monotonic() >= deadline:
+                cancel_response = self._safe_cancel("execution timeout")
+                return SessionResult(
+                    status="timed_out",
+                    success=False,
+                    error_code="GATEWAY_EXECUTION_TIMEOUT",
+                    error_message=(
+                        "Forge Gateway session exceeded execute_timeout_s="
+                        f"{self.session.timeouts.execute_timeout_s}"
+                    ),
+                    metadata={
+                        "gateway": {
+                            "create_response": created,
+                            "last_response": last_response,
+                            "cancel_response": cancel_response,
+                        },
+                        "task_status": "unknown",
+                    },
+                )
+            time.sleep(poll_interval_s)
+            last_response = self.client.get_session(payload["session_id"])
+
+    def _gateway_endpoint(self) -> str:
+        endpoint = self.session.routing.target_endpoint or self.target_spec.runtime.target_endpoint
+        if not endpoint:
+            raise ForgeGatewayError(
+                "Forge Gateway session requires routing.target_endpoint or target.runtime.target_endpoint"
+            )
+        if not endpoint.startswith(("http://", "https://")):
+            raise ForgeGatewayError(f"Forge Gateway endpoint must be HTTP(S): {endpoint}")
+        return endpoint
+
+    def _build_payload(self) -> dict[str, Any]:
+        action = dict(self.session.runtime_hints.gateway_action or {})
+        action_type = action.get("action_type") or action.get("action") or action.get("type")
+        if not isinstance(action_type, str) or not action_type:
+            raise ForgeGatewayError("runtime_hints.gateway_action.action_type is required")
+
+        inputs = action.get("inputs") or {}
+        if not isinstance(inputs, dict):
+            raise ForgeGatewayError("runtime_hints.gateway_action.inputs must be an object")
+
+        payload: dict[str, Any] = {
+            "session_id": self.session.session_id,
+            "command_id": str(action.get("command_id") or f"cmd_{self.session.session_id}"),
+            "action_type": action_type,
+            "instruction": str(action.get("instruction") or self.session.task_description),
+            "source": str(action.get("source") or "paos-agent"),
+            "inputs": dict(inputs),
+        }
+        for key, value in action.items():
+            if key in {"action_type", "action", "type", "command_id", "instruction", "source", "inputs"}:
+                continue
+            payload[key] = value
+        return payload
+
+    def _poll_interval_s(self) -> float:
+        raw = self.session.runtime_hints.gateway_action.get("poll_interval_s", 0.5)
+        try:
+            return max(0.1, min(5.0, float(raw)))
+        except (TypeError, ValueError):
+            return 0.5
+
+    def _session_status(self, response: dict[str, Any]) -> str:
+        data = response.get("data") if isinstance(response.get("data"), dict) else response
+        session = data.get("session") if isinstance(data.get("session"), dict) else {}
+        status = session.get("status") or data.get("status")
+        return str(status or "unknown")
+
+    def _safe_runtime_context(self) -> dict[str, Any] | None:
+        try:
+            return self.client.runtime_context()
+        except Exception as exc:
+            return {"ok": False, "error": str(exc)}
+
+    def _safe_cancel(self, reason: str) -> dict[str, Any] | None:
+        try:
+            return self.client.cancel_session(self.session.session_id, reason=reason)
+        except Exception as exc:
+            return {"ok": False, "error": str(exc)}
+
+    def _to_result(
+        self,
+        gateway_status: str,
+        response: dict[str, Any],
+        context: dict[str, Any] | None,
+    ) -> SessionResult:
+        data = response.get("data") if isinstance(response.get("data"), dict) else {}
+        commands = data.get("commands") if isinstance(data.get("commands"), list) else []
+        command = commands[0] if commands and isinstance(commands[0], dict) else {}
+        outputs = command.get("outputs") if isinstance(command.get("outputs"), dict) else {}
+        message = command.get("message") or data.get("msg") or ""
+        success = gateway_status == "succeeded"
+        return SessionResult(
+            status=gateway_status,
+            success=success,
+            error_code=None if success else "GATEWAY_SESSION_FAILED",
+            error_message=None if success else str(message or f"Gateway session {gateway_status}"),
+            metadata={
+                "gateway": {
+                    "status": gateway_status,
+                    "response": response,
+                    "context": context,
+                    "outputs": outputs,
+                },
+                "task_status": "not_verified" if success else "unknown",
+            },
+        )

--- a/PhyAgentOS/runtime/schemas/session.py
+++ b/PhyAgentOS/runtime/schemas/session.py
@@ -100,6 +100,7 @@ class SessionRuntimeHints(BaseModel):
     perception_queries: list[dict[str, Any]] = Field(default_factory=list)
     force_environment_refresh: bool = False
     preferred_replan_every_steps: int | None = None
+    gateway_action: dict[str, Any] = Field(default_factory=dict)
 
 
 class SessionSafetyProfile(BaseModel):

--- a/PhyAgentOS/runtime/watchdog/supervisor.py
+++ b/PhyAgentOS/runtime/watchdog/supervisor.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from pydantic import ValidationError
 
+from PhyAgentOS.runtime.gateway import GatewaySessionRunner
 from PhyAgentOS.runtime.perception import PerceptionRuntime
 from PhyAgentOS.runtime.policy.factory import build_policy_client
 from PhyAgentOS.runtime.preflight import RuntimeCompatibilityPreflight
@@ -72,6 +73,30 @@ class WatchdogSupervisor:
             self.registry.mark_preflight_checking(session_id)
             session = self.registry.get_session(session_id)
             scheduled = self.scheduler.resolve_session(session, targets_doc, skillruntimes_doc)
+            if self._is_gateway_session(scheduled):
+                # Compatibility bridge: Phase-3 PAOS still queues Gateway work
+                # through SESSIONS.md. The next adapter should call
+                # ForgeGatewayClient directly from the Agent command layer.
+                if not scheduled.target_spec.enabled:
+                    raise SchemaValidationError(f"target {scheduled.target_id} is disabled")
+                self.registry.mark_running(session_id)
+                session = self.registry.get_session(session_id)
+                scheduled = self.scheduler.resolve_session(session, targets_doc, skillruntimes_doc)
+                result = GatewaySessionRunner(
+                    session=session,
+                    target_spec=scheduled.target_spec,
+                    skillruntime_spec=scheduled.skillruntime_spec,
+                ).run()
+                self.registry.mark_finalizing(session_id)
+                result = self.result_writer.write_episode(
+                    session,
+                    scheduled.target_spec,
+                    scheduled.skillruntime_id,
+                    result,
+                )
+                self.result_writer.write_session_history(session, scheduled.target_spec, result)
+                self.registry.mark_finished(session_id, result)
+                return True
             health_report = self.health_monitor.preflight(scheduled)
             if not health_report.ok:
                 raise SchemaValidationError(health_report.summary())
@@ -211,6 +236,12 @@ class WatchdogSupervisor:
             timeout_s=session.timeouts.policy_timeout_s,
             action_dim=int(action_dim),
             chunk_size=int(chunk_size),
+        )
+
+    def _is_gateway_session(self, scheduled) -> bool:
+        return (
+            scheduled.skillruntime_spec.runtime == "ForgeGatewaySkillRuntime"
+            or scheduled.target_spec.runtime.target_runtime == "ForgeGatewayRuntime"
         )
 
     def _close_policy_client(self, policy_client) -> None:

--- a/PhyAgentOS/runtime/workspace/manager.py
+++ b/PhyAgentOS/runtime/workspace/manager.py
@@ -20,6 +20,7 @@ RUNTIME_TEMPLATE_NAMES = ("TARGETS.md", "SKILLRUNTIME.md")
 RUNTIME_CONFIG_TEMPLATE_NAMES = (
     "configs/runtime/contracts/dummy_sim.runtime.yaml",
     "configs/runtime/contracts/libero_real.runtime.yaml",
+    "configs/runtime/contracts/forge_gateway.runtime.yaml",
     "configs/runtime/sensors/dummy_sim.sensors.yaml",
 )
 _RUNTIME_INSTRUCTIONS = """# Runtime Protocol
@@ -93,6 +94,82 @@ Rules:
   provides a different endpoint.
 - Do not manually edit `ENVIRONMENT.md`; it is runtime state managed by
   PhyAgentOS.
+
+## Forge Gateway MVP+
+
+When an enabled target uses `target_runtime: ForgeGatewayRuntime` and a
+skillruntime uses `runtime: ForgeGatewaySkillRuntime`, the watchdog sends one
+high-level action to the Forge Gateway `/agent/sessions` API instead of running
+the legacy target / policy loop.
+
+Gateway sessions require `runtime_hints.gateway_action`:
+
+```yaml
+runtime_hints:
+  gateway_action:
+    action_type: grasp
+    target_name: apple
+    source: paos-agent
+    inputs:
+      auto_home: false
+```
+
+Rules:
+
+- Use `routing.target_endpoint` or `TARGETS.md runtime.target_endpoint` as the
+  Forge Gateway HTTP base URL, for example `http://127.0.0.1:9001`.
+- `session_id` is forwarded to Gateway; PAOS generates `command_id` as
+  `cmd_{session_id}` unless `gateway_action.command_id` is provided.
+- Gateway MVP+ is serial: do not create concurrent pending sessions for the
+  same robot.
+- A Gateway `succeeded` status is command-level success. Treat physical task
+  success as `not_verified` unless a verifier or human observation confirms it.
+
+### SAM3 Gateway Action Mapping
+
+For SAM3 / Piper Gateway sessions, preserve PAOS Agent semantics: translate the
+user's natural-language intent into a runtime session, then append it to
+`SESSIONS.md`. Do not call Forge Gateway directly from the Agent.
+
+Use this default target and skillruntime when they are enabled and support the
+requested action:
+
+```yaml
+target_ref: target://forge_gateway
+skillruntime_ref: skillruntime://forge_gateway_sam3
+routing:
+  target_endpoint: http://127.0.0.1:9001
+  policy_endpoint: null
+```
+
+Natural-language mapping:
+
+- "抓取/拿起/取/夹取 <object>" or "grasp/pick up <object>" ->
+  `gateway_action.action_type: grasp`, `gateway_action.target_name: <object>`.
+- "放置/放下/放到 <place>" or "place/put down <object>" ->
+  `gateway_action.action_type: place`, include `target_name` or placement text
+  when the user provides it.
+- "检查/确认/看一下是否有 <object>" or "check/find <object>" ->
+  `gateway_action.action_type: check_target`, `gateway_action.target_name: <object>`.
+- "回到初始位/回零/回家" or "go home/reset pose" ->
+  `gateway_action.action_type: go_home`.
+- "场景复位/重置仿真环境/reset scene" -> do not edit `SESSIONS.md`.
+  Execute the Agent command adapter instead:
+  `python -m PhyAgentOS.runtime.gateway.command_adapter --workspace <runtime_workspace> reset`.
+  This calls `POST /agent/runtime/reset`, which is not a session action.
+
+Gateway session rules:
+
+- Use a short unique `session_id`, for example
+  `sess_gateway_grasp_apple_<short_suffix>`.
+- Put the original user request in `task_description`.
+- Set `runtime_hints.gateway_action.source: paos-agent`.
+- Put extra action arguments under `runtime_hints.gateway_action.inputs`.
+- For grasp-like actions, default `inputs.auto_home` to `false` unless the user
+  asks to return home automatically.
+- If the user asks for a multi-step task, create one pending session at a time
+  and wait for the previous Gateway session to reach a terminal state before
+  appending the next one.
 """
 
 

--- a/PhyAgentOS/templates/SESSIONS.md
+++ b/PhyAgentOS/templates/SESSIONS.md
@@ -71,4 +71,44 @@ sessions:
       workspace_bounds: default
       stop_on_policy_timeout: true
     result: {}
+  - session_id: sess_gateway_grasp_apple_example
+    goal_id: goal_gateway_sam3_example
+    target_ref: target://forge_gateway
+    skillruntime_ref: skillruntime://forge_gateway_sam3
+    task_description: grasp apple through Forge Gateway
+    status: pending
+    priority: low
+    timeouts:
+      queue_timeout_s: 30
+      preflight_timeout_s: 20
+      execute_timeout_s: 120
+      policy_timeout_s: 10
+    retry:
+      max_retries: 0
+      attempted: 0
+    routing:
+      target_endpoint: http://127.0.0.1:9001
+      policy_endpoint: null
+      adapter_resolution: strict_auto
+      adapter_overrides: null
+    execution:
+      max_steps: 1
+      replan_every_steps: 1
+      action_chunk_mode: single_step
+      chunk_switch_mode: hard_switch
+    runtime_hints:
+      perception_queries: []
+      force_environment_refresh: false
+      preferred_replan_every_steps: 1
+      gateway_action:
+        action_type: grasp
+        target_name: apple
+        source: paos-agent
+        inputs:
+          auto_home: false
+    safety_profile:
+      profile: default_simulation
+      workspace_bounds: default
+      stop_on_policy_timeout: true
+    result: {}
 ```

--- a/PhyAgentOS/templates/SKILLRUNTIME.md
+++ b/PhyAgentOS/templates/SKILLRUNTIME.md
@@ -89,4 +89,31 @@ skillruntimes:
       forbidden:
         - implicit_shape_truncation
         - implicit_representation_cast
+  - id: forge_gateway_sam3
+    runtime: ForgeGatewaySkillRuntime
+    runtime_kind: builtin
+    loop_mode: gateway_single_action
+    agent_exposure: none
+    supported_target_kinds:
+      - simulation
+      - real_robot
+    observation_contract:
+      observation_type: empty
+      empty_observation_allowed: true
+      empty_observation_semantics: gateway_runtime_context
+    supports_chunk: false
+    default_replan_every: 1
+    requires:
+      sensors: []
+      environment_outputs: []
+      strict_environment_contract: false
+    input_contract:
+      gateway_action:
+        required: true
+        fields:
+          - action_type
+          - inputs
+    output_contract:
+      gateway_result:
+        status_source: /agent/sessions/{session_id}
 ```

--- a/PhyAgentOS/templates/TARGETS.md
+++ b/PhyAgentOS/templates/TARGETS.md
@@ -63,4 +63,29 @@ targets:
       max_chunk_size: 50
       max_steps: 280
       num_steps_wait: 10
+  - id: forge_gateway
+    target_class: remote
+    target_kind: simulation
+    enabled: true
+    workspace: workspaces/forge_gateway
+    supported_skillruntimes:
+      - forge_gateway_sam3
+    runtime:
+      target_runtime: ForgeGatewayRuntime
+      target_endpoint: http://127.0.0.1:9001
+      target_adapter: target_adapter://forge_gateway_passthrough
+      runtime_contract_ref: configs/runtime/contracts/forge_gateway.runtime.yaml
+    observation:
+      observation_type: empty
+      empty_observation_allowed: true
+      empty_observation_semantics: gateway_runtime_context
+    perception:
+      enabled: false
+      strict_preflight: true
+      sensor_config_ref: null
+      perception_config_ref: null
+      artifact_dir: null
+    config:
+      gateway_api: paos-forge-gateway-mvp-plus.v1
+      action_manifest: actions/piper/sam3.md
 ```

--- a/PhyAgentOS/templates/configs/runtime/contracts/forge_gateway.runtime.yaml
+++ b/PhyAgentOS/templates/configs/runtime/contracts/forge_gateway.runtime.yaml
@@ -1,0 +1,34 @@
+version: runtime_target_contract_v1
+target_id: forge_gateway
+target_adapter: target_adapter://forge_gateway_passthrough
+observation:
+  schema_source: gateway_runtime_context
+  require_describe_observation_schema: false
+  allow_extra_channels: true
+  timestamp_required: false
+action_contract:
+  id: forge_gateway_action_v1
+  accepted_representations:
+    - gateway_action
+  shape:
+    - 1
+    - 1
+  dtype: object
+  normalized: false
+  frame: gateway
+  control_mode: gateway_single_action
+  control_hz: 1
+  components:
+    - {name: action_type, unit: string}
+  chunk:
+    max_chunk_size: 1
+    preferred_chunk_size: 1
+    preferred_replan_after_steps: 1
+    switch_policy: hard_switch
+safety:
+  require_target_side_validation: true
+  stop_on_nan: true
+  stop_on_timeout: true
+capabilities:
+  gateway_api: paos-forge-gateway-mvp-plus.v1
+  serial_actions_only: true

--- a/docs/forge/README.md
+++ b/docs/forge/README.md
@@ -1,0 +1,271 @@
+# PAOS Forge Gateway MVP+
+
+本文档面向当前 MVP+ 验证：PAOS 保留 Agent 语义层，Forge Gateway / Dora dataflow 承担底层动作执行。当前目标是跑通 Phase 3 闭环，不替换全部 PAOS Runtime v2 代码。
+
+## Quick Start
+
+### 1. 启动 Forge Gateway Dataflow
+
+以 `sam3_grasp_runner` 仿真为例：
+
+```bash
+cd /path/to/sam3_grasp_runner
+bash scripts/run_sim_rgbd.sh
+```
+
+确认 Gateway 可访问：
+
+```bash
+curl -sS http://127.0.0.1:9001/agent/runtime/capabilities | jq
+```
+
+预期能看到：
+
+- `supports.sessions: true`
+- `supports.serial_actions_only: true`
+- `actions.grasp`
+- `actions.place`
+- `actions.check_target`
+- `actions.go_home`
+
+### 2. 初始化 PAOS Runtime Workspace
+
+```bash
+cd /path/to/PhyAgentOS
+python scripts/init_runtime_workspace.py --workspace ~/.PhyAgentOS/workspace
+```
+
+该命令会创建：
+
+- `TARGETS.md`
+- `SKILLRUNTIME.md`
+- `SESSIONS.md`
+- `RUNTIME.md`
+- `ENVIRONMENT.md`
+- `configs/runtime/*`
+
+如果文件已存在，默认不会覆盖；只有需要重置模板时才使用 `--force`。
+
+### 3. 启用 Forge Gateway Target
+
+在 `~/.PhyAgentOS/workspace/TARGETS.md` 中启用 `forge_gateway`：
+
+```yaml
+- id: forge_gateway
+  target_class: remote
+  target_kind: simulation
+  enabled: true
+  workspace: workspaces/forge_gateway
+  supported_skillruntimes:
+    - forge_gateway_sam3
+  runtime:
+    target_runtime: ForgeGatewayRuntime
+    target_endpoint: http://127.0.0.1:9001
+    target_adapter: target_adapter://forge_gateway_passthrough
+    runtime_contract_ref: configs/runtime/contracts/forge_gateway.runtime.yaml
+```
+
+`target_endpoint` 指向 Forge Gateway HTTP 地址。旧 workspace 可能仍使用 `forge_gateway_piper_sim`，建议迁移到 `forge_gateway`。
+
+### 4. 启动 PAOS Agent
+
+开发分支验证时推荐使用源码入口，避免加载环境中旧版 `paos`：
+
+```bash
+cd /path/to/PhyAgentOS
+python -m PhyAgentOS agent --workspace ~/.PhyAgentOS/workspace --logs
+```
+
+如果希望 `paos` 命令也指向当前源码：
+
+```bash
+cd /path/to/PhyAgentOS
+python -m pip install -e .
+```
+
+## 命令示例
+
+### 自然语言动作
+
+PAOS Agent 会读取 runtime workspace 中的 `RUNTIME.md`、`TARGETS.md`、`SKILLRUNTIME.md` 和 `SESSIONS.md`。动作类请求会被翻译成 `SESSIONS.md` 中的 `runtime_hints.gateway_action`。
+
+示例：
+
+```text
+帮我通过 Forge Gateway 抓取苹果
+检查一下桌面上是否有 apple
+让机械臂回到初始位
+```
+
+常用映射：
+
+
+| 用户意图       | `gateway_action.action_type` | 关键参数                 |
+| ---------- | ---------------------------- | -------------------- |
+| 抓取/拿起/夹取苹果 | `grasp`                      | `target_name: apple` |
+| 放下/放置物体    | `place`                      | `target_name` 或放置描述  |
+| 检查是否有苹果    | `check_target`               | `target_name: apple` |
+| 回到初始位/回家   | `go_home`                    | 无必需目标                |
+
+
+### 手动追加 Action Session
+
+如果不通过自然语言，也可以手动向 `SESSIONS.md` 追加 pending session：
+
+```yaml
+- session_id: sess_gateway_grasp_apple
+  goal_id: goal_gateway_sam3
+  target_ref: target://forge_gateway
+  skillruntime_ref: skillruntime://forge_gateway_sam3
+  task_description: grasp apple through Forge Gateway
+  status: pending
+  priority: normal
+  routing:
+    target_endpoint: http://127.0.0.1:9001
+    policy_endpoint: null
+  runtime_hints:
+    gateway_action:
+      action_type: grasp
+      target_name: apple
+      source: paos-agent
+      inputs:
+        auto_home: false
+  result: {}
+```
+
+然后手动执行一次 watchdog：
+
+```bash
+cd /path/to/PhyAgentOS
+python scripts/run_runtime_watchdog.py --workspace ~/.PhyAgentOS/workspace --once
+```
+
+### 场景复位
+
+场景复位不是普通 action session。不要向 `SESSIONS.md` 追加 `action_type: reset`，应直接调用 Agent command adapter：
+
+```bash
+cd /path/to/PhyAgentOS
+python -m PhyAgentOS.runtime.gateway.command_adapter --workspace ~/.PhyAgentOS/workspace reset
+```
+
+该命令会读取 `TARGETS.md` 中的 Gateway endpoint，并调用：
+
+```http
+POST /agent/runtime/reset
+```
+
+Gateway 内部复用 `reset_scene` runtime 命令，由 dataflow 完成仿真环境复位。
+
+### 验证状态
+
+查看 Gateway runtime context：
+
+```bash
+curl -sS http://127.0.0.1:9001/agent/runtime/context | jq
+```
+
+查看 PAOS session 状态：
+
+```bash
+rg "sess_gateway|status:|result:" ~/.PhyAgentOS/workspace/SESSIONS.md
+```
+
+查看 PAOS runtime log：
+
+```bash
+sed -n '1,200p' ~/.PhyAgentOS/workspace/LOG.md
+```
+
+## 当前调用链路
+
+当前实现同时存在两条链路。
+
+### Action Session 链路
+
+动作类任务走现有 PAOS Runtime v2 bridge：
+
+```text
+用户自然语言
+  -> PAOS Agent
+  -> 写入 SESSIONS.md
+  -> WatchdogSupervisor
+  -> GatewaySessionRunner
+  -> POST /agent/sessions
+  -> Forge Gateway
+  -> Dora PolicyCommand
+  -> policy_command_status
+  -> PAOS SessionResult / LOG.md
+```
+
+触发条件是 session 绑定到 Forge Gateway target 或 skillruntime：
+
+```yaml
+target_ref: target://forge_gateway
+skillruntime_ref: skillruntime://forge_gateway_sam3
+runtime_hints:
+  gateway_action:
+    action_type: grasp
+```
+
+代码入口：
+
+- `PhyAgentOS/runtime/gateway/session_runner.py`
+- `PhyAgentOS/runtime/watchdog/supervisor.py`
+- `PhyAgentOS/runtime/gateway/client.py`
+
+这条链路适合需要 session 状态和结果写回的动作，例如 `grasp`、`place`、`check_target`、`go_home`。
+
+### Runtime Command 链路
+
+非 action session 的运行时控制命令走 command adapter：
+
+```text
+PAOS Agent / manual command
+  -> ForgeGatewayCommandAdapter
+  -> ForgeGatewayClient
+  -> POST /agent/runtime/reset
+  -> Forge Gateway
+  -> reset_scene
+  -> Dora dataflow
+```
+
+代码入口：
+
+- `PhyAgentOS/runtime/gateway/command_adapter.py`
+- `PhyAgentOS/runtime/gateway/client.py`
+
+当前已支持：
+
+```bash
+python -m PhyAgentOS.runtime.gateway.command_adapter --workspace ~/.PhyAgentOS/workspace reset
+```
+
+## 后续规划
+
+当前 `SESSIONS.md + WatchdogSupervisor + GatewaySessionRunner` 是 Phase 3 兼容路径，用于最小代价接入 PAOS Runtime v2 的会话队列。
+
+后续建议逐步收敛为统一的 Agent command adapter：
+
+```text
+用户自然语言
+  -> PAOS Agent planner
+  -> ForgeGatewayCommandAdapter
+  -> Forge Gateway /agent/*
+  -> Forge dataflow
+  -> runtime context / result
+  -> PAOS Agent
+```
+
+目标 adapter 形态：
+
+```python
+adapter.get_capabilities()
+adapter.create_action_session(action_type="grasp", inputs={"target_name": "apple"})
+adapter.get_session(session_id)
+adapter.cancel_session(session_id)
+adapter.reset_runtime()
+adapter.get_context()
+```
+
+长期目标是让 PAOS Agent 只理解 Gateway capabilities、action manifest、runtime context 和 result，不再依赖 PAOS Runtime v2 的 target / skillruntime 执行模型。

--- a/docs/forge/forge_gateway_action_manifest_design.md
+++ b/docs/forge/forge_gateway_action_manifest_design.md
@@ -1,0 +1,432 @@
+# Forge Gateway Action Manifest 组织设计
+
+## 1. 背景与目标
+
+PAOS-Forge 融合后，PAOS Agent 负责高层任务理解、规划与决策，Forge Gateway 负责将 Agent action 稳定映射到 Forge dataflow 内的 policy command，并汇总运行时状态。
+
+因此，Gateway 的 action 定义不应长期写在 `config.yaml` 中。`config.yaml` 更适合描述端口、状态目录、readiness、`policy_id` 等基础运行配置；而 action 是面向 Agent 和人的能力说明，应该以类似 PAOS `SKILLS.md` 的方式组织成 Markdown manifest。
+
+本设计目标：
+
+- 将 action 能力定义从基础配置中拆出。
+- 使用 Markdown 作为 Agent/人类可读上下文。
+- 使用 YAML frontmatter 作为 Gateway 可解析的确定性协议源。
+- 支持同一 robot 下多个 policy manifest。
+- 为复杂多步骤任务保留 Gateway 层支持能力，但短期不改造 PAOS Agent 代码。
+
+## 2. 路径规范
+
+推荐路径：
+
+```text
+./actions/{robot_id}/{policy_id}.md
+```
+
+示例：
+
+```text
+actions/
+└── piper/
+    ├── sam3.md
+    ├── nav.md
+    └── pour.md
+```
+
+路径语义：
+
+- `{robot_id}` 表示机器人或运行目标，例如 `piper`、`franka`、`aloha`、`mujoco_piper`。
+- `{policy_id}` 表示 Forge dataflow 内可接收 `PolicyCommand.policy_id` 的 policy 节点或策略能力域，例如 `sam3`、`nav`、`pour`。
+- 一个文件只描述一个 `robot_id + policy_id` 下的 action 集合。
+- Gateway 可加载多个 manifest，并汇总为 `/agent/runtime/capabilities`。
+
+与 `./actions/{policy}_{robot}.md` 相比，`./actions/{robot_id}/{policy_id}.md` 更利于按机器人隔离能力集，也更符合未来多 policy、多机器人、多部署环境的组织方式。
+
+## 3. Gateway 配置方式
+
+Gateway 基础配置只保存 manifest 路径，不直接内嵌 action 映射。
+
+示例：
+
+```yaml
+agent:
+  enabled: true
+  state_dir: /tmp/paos_forge_gateway_state
+  write_context_snapshot: true
+  action_manifests:
+    - ./actions/piper/sam3.md
+    - ./actions/piper/nav.md
+    - ./actions/piper/pour.md
+```
+
+路径解析建议：
+
+- 相对路径优先相对 Gateway 配置文件所在目录解析。
+- 也可支持绝对路径，方便部署包外置 manifest。
+- Gateway 启动时解析 manifest，失败时应明确报错，避免运行时 action 路由不确定。
+- MVP 阶段可保留内置默认 manifest 作为 fallback，但生产部署应显式配置 `action_manifests`。
+
+当前实现：
+
+- Gateway 包内置默认 manifest：`forge_runtime/packages/nodes/gateway/actions/piper/sam3.md`。
+- `sam3_grasp_runner` 仿真配置显式使用：`sam3_grasp_runner/actions/piper/sam3.md`。
+- `sam3_grasp_runner/configs/common/sam3_gateway.yaml` 通过 `agent.action_manifests: ../../actions/piper/sam3.md` 加载 action。
+- `sam3_grasp_runner/dataflows/sim/sam3_dataflow_sim.yaml` 将 `sam3_policy/policy_command_status` 回连到 `gateway/policy_command_status`。
+
+## 4. Manifest 文件结构
+
+Manifest 使用 Markdown + YAML frontmatter。Gateway 只解析 frontmatter，Markdown 正文作为 Agent/人类可读说明。
+
+Frontmatter 示例：
+
+```yaml
+---
+version: 1
+robot_id: piper
+policy_id: sam3
+policy_command_topic: gateway/policy_command
+status_topic: sam3_policy/policy_command_status
+actions:
+  grasp:
+    command: grasp_simple
+    required_parameters: ["target_name"]
+    input_mapping:
+      target: target_name
+      target_name: target_name
+    resources: ["arm", "gripper", "camera"]
+    timeout_s: 120
+    result_semantics: command_completed
+    completion:
+      type: policy_status
+    description: "抓取指定目标物体"
+
+  place:
+    command: explore_and_place
+    required_parameters: ["target_name"]
+    input_mapping:
+      target: target_name
+      target_name: target_name
+    resources: ["arm", "gripper", "camera"]
+    timeout_s: 120
+    result_semantics: command_completed
+    completion:
+      type: policy_status
+    description: "将已抓取物体放置到目标区域"
+
+  check_target:
+    command: check_target
+    required_parameters: ["target_name"]
+    input_mapping:
+      target: target_name
+      target_name: target_name
+    resources: ["camera"]
+    timeout_s: 30
+    result_semantics: task_verified
+    completion:
+      type: policy_status
+    description: "检查目标物体是否可见"
+---
+```
+
+Markdown 正文示例：
+
+````markdown
+# SAM3 Piper Actions
+
+本文件描述 Piper 机器人在 SAM3 policy 下可供 PAOS Agent 调用的高层动作。
+
+## 约束
+
+- `grasp` 需要目标物体在相机视野中可检测。
+- `place` 默认表示将已抓取物体放置到指定目标区域。
+- 当前 `succeeded` 表示 policy 已接受并完成命令级反馈，不等价于长期任务目标一定成功。
+
+## 示例
+
+抓取苹果：
+
+```json
+{
+  "action_type": "grasp",
+  "target_name": "apple"
+}
+```
+````
+
+设计原则：
+
+- Gateway 只解析 frontmatter，不从 Markdown 正文推断协议。
+- Markdown 正文用于 Agent 上下文、人类说明、限制条件、示例、已知失败模式。
+- `actions.*.command` 映射到 `forge_msgs.PolicyCommand.command`。
+- `policy_id` 映射到 `forge_msgs.PolicyCommand.policy_id`。
+- `required_parameters` 用于 Gateway 入参校验。
+- `input_mapping` 用于兼容 Agent 参数命名与 policy 输入命名。
+- `timeout_s` 可作为 Watchdog MVP+ 的命令超时参考。
+- `resources` 用于描述该 action 可能占用的机器人资源；MVP+ 仅记录，不用于开启并行。
+- `completion` 用于描述 Gateway 如何判断该 action 的命令级完成状态。
+
+## 5. Capabilities 汇总
+
+Gateway 启动后解析所有 action manifest，并在 `/agent/runtime/capabilities` 中返回结构化能力清单。
+
+示例：
+
+```json
+{
+  "api_version": "paos-forge-gateway-mvp-plus.v1",
+  "robot_id": "piper",
+  "supports": {
+    "sessions": true,
+    "command_id": true,
+    "runtime_context": true,
+    "serial_actions_only": true
+  },
+  "policies": {
+    "sam3": {
+      "manifest": "./actions/piper/sam3.md",
+      "actions": {
+        "grasp": {
+          "command": "grasp_simple",
+          "required_parameters": ["target_name"],
+          "description": "抓取指定目标物体"
+        },
+        "place": {
+          "command": "explore_and_place",
+          "required_parameters": ["target_name"],
+          "description": "将已抓取物体放置到目标区域"
+        }
+      }
+    },
+    "nav": {
+      "manifest": "./actions/piper/nav.md",
+      "actions": {
+        "move_to": {
+          "command": "move_to",
+          "required_parameters": ["location"],
+          "description": "移动到指定语义位置"
+        }
+      }
+    }
+  }
+}
+```
+
+为了方便 PAOS Agent 获取完整上下文，Gateway 可在 `/agent/runtime/context` 中附带：
+
+- 当前已加载 manifest 列表。
+- 每个 policy 的 action 摘要。
+- 当前 robot/environment 状态。
+- 最近一次 command/session 结果。
+- 可选的 manifest Markdown 原文路径或摘要。
+
+## 6. Agent Session 到 PolicyCommand 的映射
+
+PAOS Agent 仍通过 `/agent/sessions` 创建单步 session。
+
+请求示例：
+
+```json
+{
+  "session_id": "sess_grasp_001",
+  "command_id": "cmd_grasp_001",
+  "action_type": "grasp",
+  "target_name": "coffee_cup",
+  "source": "paos-agent"
+}
+```
+
+Gateway 根据 manifest 解析：
+
+```text
+action_type=grasp
+  -> policy_id=sam3
+  -> command=grasp_simple
+  -> inputs.target_name=coffee_cup
+  -> request_id=cmd_grasp_001
+```
+
+下发到 Forge：
+
+```json
+{
+  "policy_id": "sam3",
+  "command": "grasp_simple",
+  "request_id": "cmd_grasp_001",
+  "inputs_json": {
+    "session_id": "sess_grasp_001",
+    "command_id": "cmd_grasp_001",
+    "action_type": "grasp",
+    "target_name": "coffee_cup",
+    "source": "paos-agent"
+  }
+}
+```
+
+policy 返回 `PolicyCommandStatus` 后，Gateway 通过 `request_id` 或 `outputs.command_id` 关联 `CommandState`，并更新 session 到 `running`、`succeeded`、`failed`、`cancelled` 等状态。
+
+## 7. 复杂任务支持方案
+
+示例复杂任务：
+
+```text
+移动到茶水间 -> 抓起咖啡杯 -> 倒咖啡 -> 将咖啡杯送回桌上
+```
+
+底层可能涉及多个 policy：
+
+```text
+nav.move_to(location="tea_room")
+sam3.grasp(target_name="coffee_cup")
+pour.pour_into(target_name="coffee_cup", source="coffee_machine")
+nav.move_to(location="desk")
+sam3.place(target_name="desk")
+```
+
+短期推荐采用 **Agent-orchestrated workflow**：
+
+1. PAOS Agent 读取 `/agent/runtime/capabilities` 和 action manifest。
+2. Agent 根据用户目标生成步骤计划。
+3. Agent 逐步调用 `/agent/sessions`。
+4. 每一步等待 Gateway 返回 `succeeded` 或 `failed`。
+5. Agent 根据 `/agent/runtime/context` 判断下一步、重试或终止。
+
+该模式下：
+
+- PAOS Agent 是 planner 和 workflow owner。
+- Gateway 不负责长程任务规划。
+- Gateway 负责 action 校验、policy 路由、session/command 状态、runtime context 聚合。
+- Forge dataflow 负责实际 policy 执行与反馈。
+
+### 7.1 Gateway 的职责边界
+
+复杂任务的长程规划不应由 Gateway 控制。Gateway 在架构上是 **上层控制动作入口** 和 **Forge runtime control plane**，不是 planner。
+
+Gateway 应提供：
+
+- 可发现的 action capabilities。
+- 稳定的 `/agent/sessions` action 调用入口。
+- action 到 `PolicyCommand` 的确定性映射。
+- session/command 状态机。
+- `runtime_context`、event log、snapshot。
+- 可选的 workflow trace 记录。
+
+Gateway 不应负责：
+
+- 将用户自然语言拆成完整长程计划。
+- 决定复杂任务的下一步语义动作。
+- 根据失败结果自动重写计划。
+- 承担跨 policy 的高层任务目标验证。
+
+这些能力更适合保留在 PAOS Agent 层。Gateway 只需要把底层可执行动作、状态和结果稳定暴露给 Agent。
+
+### 7.2 串行与并发策略
+
+MVP+ 阶段采用 **同一 robot 强制串行执行**：
+
+- 同一时刻只允许一个会占用 robot 执行资源的 action 处于 `queued/running`。
+- `nav`、`sam3`、`pour` 等不同 policy 可以同时存在于 Forge dataflow 中，但 Gateway 本期不会让它们并发接管同一台 robot。
+- 对机械臂、夹爪、底盘、相机感知等 action，本期统一按串行 session 处理。
+- 不提供通过 manifest 或 `config.yaml` 打开并行动作的配置项。
+
+Manifest 中可以保留 `resources` 作为未来资源锁元数据：
+
+```yaml
+resources: ["arm", "gripper"]
+```
+
+但 MVP+ 不根据 `resources` 做并发调度。Gateway 应以全局 active session 约束实现串行执行，例如同一时刻只允许一个 `queued/running` session。未来如果要支持部分动作并发，再基于 `resources` 增加资源锁和冲突检测。
+
+## 8. Gateway 层预留能力
+
+虽然短期不改造 PAOS Agent 层代码，Gateway 仍应为复杂动作保留少量扩展点。MVP+ 只做记录和暴露，不做调度。
+
+### 8.1 Workflow Trace
+
+Gateway 可在内存状态、event log 和 `runtime_context.json` 中记录来自同一上层任务的多个 session。
+
+建议请求字段：
+
+```json
+{
+  "goal_id": "goal_make_coffee_001",
+  "step_index": 2,
+  "depends_on": ["cmd_move_to_tea_room"]
+}
+```
+
+MVP+ 可先只记录，不做调度。
+
+### 8.2 Context Carry-over
+
+上一步 policy 的输出可进入 `runtime_context.last_result`，由 PAOS Agent 读取后决定下一步。Gateway 不理解业务语义，只负责稳定保存和暴露结果。
+
+例如：
+
+```json
+{
+  "last_result": {
+    "policy_id": "sam3",
+    "command": "check_target",
+    "outputs": {
+      "found": true,
+      "target_pose": "optional"
+    }
+  }
+}
+```
+
+### 8.3 未来预留字段
+
+Manifest 可保留少量未来字段，但 MVP+ 不围绕这些字段实现复杂逻辑：
+
+```yaml
+resources: ["arm", "gripper"]
+preconditions:
+  - runtime.ready == true
+  - gripper.empty == true
+result_semantics: command_completed
+completion:
+  type: policy_status
+```
+
+这些字段本期主要用于 capabilities 展示和 Agent 提示。并行调度、资源锁、复杂前置条件校验、VLA 结束态判断都不在 MVP+ 范围内。
+
+### 8.4 VLA 简化原则
+
+后续引入 VLA 模型时，需要注意 VLA 可能没有自然结束态。MVP+ 只保留一个原则：不要把 VLA 的“命令已启动”误认为“任务已完成”。
+
+如果某个 VLA action 只能持续运行并等待外部停止，则它的 `result_semantics` 应标记为 `command_accepted` 或类似语义；真正的任务成功应由 PAOS Agent、用户确认或额外 verifier action 判断。Gateway 本期只负责保持 session 状态、支持 cancel/stop，并暴露最新上下文。
+
+## 9. 不建议短期实现的内容
+
+MVP+ 不实现 Gateway workflow engine，也不实现可配置并行动作。Gateway 当前重心是稳定打通 action manifest、串行 session 状态、policy 路由和 context 闭环。
+
+以下能力只保留为后续方向：
+
+- workflow DAG 调度。
+- 跨 policy 自动回滚。
+- 复杂条件分支。
+- 可配置资源并发。
+- VLA 任务成功自动判定。
+
+## 10. 分阶段实施建议
+
+### Phase 1：Manifest 外置
+
+- 新增 `action_manifests` 配置。
+- 新增 `./actions/{robot_id}/{policy_id}.md` 解析。
+- `/agent/runtime/capabilities` 返回 manifest 汇总结果。
+- `/agent/sessions` 使用 manifest 做 action -> policy command 映射。
+- Gateway 强制保持同一 robot 串行 session，不提供并行配置。
+
+### Phase 2：Context 增强
+
+- `/agent/runtime/context` 暴露 manifest 摘要。
+- event log 记录 manifest action、policy_id、robot_id。
+- `runtime_context.json` 记录当前 robot/action capabilities。
+- 可选记录 `goal_id`、`step_index`、`depends_on`，但只作为 trace，不做调度。
+
+## 11. 结论
+
+`./actions/{robot_id}/{policy_id}.md` 是更合理的 action 组织方式。它把机器人维度、policy 维度和 Agent 可读能力文档自然分开，同时保留 Gateway 对 action 的确定性解析能力。
+
+复杂任务的短期最佳路径不是把 Gateway 改造成 planner，而是让 PAOS Agent 基于 capabilities 和 action manifest 做步骤规划，并逐步调用 `/agent/sessions`。Gateway 保持 runtime control plane 职责，提供 policy 路由、状态跟踪、事件日志、runtime context 和未来 workflow trace 扩展点。

--- a/docs/forge/forge_gateway_mvp_plus_design.md
+++ b/docs/forge/forge_gateway_mvp_plus_design.md
@@ -1,0 +1,416 @@
+# Forge Gateway MVP+ 详细设计
+
+### 2.1 MVP+ 定义
+
+MVP+ 指：
+
+- Gateway 使用内存作为运行态 source of truth。
+- Gateway 写 JSONL 事件日志作为审计和弱恢复。
+- Gateway 写 `runtime_context.json` snapshot 作为 Agent 可读上下文镜像。
+- 不引入数据库。
+- 不做强一致恢复。
+
+推荐存储层级：
+
+```text
+Source of truth:
+  Gateway 内存状态
+
+Durable audit:
+  runtime_state/events.jsonl
+
+Agent-visible snapshot:
+  runtime_state/runtime_context.json
+  可选 FORGE_RUNTIME.md / ENVIRONMENT.md
+```
+
+### 2.2 Gateway 内部模块
+
+```text
+Forge Gateway
+├── Agent API Server
+├── Session Store
+├── Command Mapper
+├── Action Manifest Loader
+├── Dora IO Adapter
+├── Runtime State Aggregator
+├── Runtime Context Builder
+├── Event Log Writer
+└── Snapshot Writer
+```
+
+#### Agent API Server
+
+提供：
+
+- `POST /agent/sessions`
+- `GET /agent/sessions/{session_id}`
+- `POST /agent/sessions/{session_id}/cancel`
+- `GET /agent/runtime/status`
+- `GET /agent/runtime/context`
+- `GET /agent/runtime/capabilities`
+
+#### Session Store
+
+维护：
+
+```text
+sessions: dict[str, SessionState]
+commands: dict[str, CommandState]
+nodes: dict[str, NodeStatus]
+active_session_id: str | None
+last_result: dict | None
+```
+
+#### Command Mapper
+
+负责：
+
+- 基于 action manifest 校验 Agent action。
+- 将 `action_type` 映射到 `policy_id + PolicyCommand.command`。
+- 将 Agent parameters 映射到 `PolicyCommand.inputs`。
+- 注入 `session_id`、`command_id`、`instruction`、`source`。
+- 将 `command_id` 映射为 `PolicyCommand.request_id`。
+
+#### Action Manifest Loader
+
+负责：
+
+- 读取 `agent.action_manifests`。
+- 解析 `./actions/{robot_id}/{policy_id}.md` 的 YAML frontmatter。
+- 汇总 `robot_id`、`policy_id`、`actions`、`required_parameters`、`input_mapping`、`resources`、`timeout_s`、`completion`。
+- 生成 `/agent/runtime/capabilities` 的 `policies` 和 `actions` 视图。
+- MVP+ 阶段强制串行执行 action，不提供配置化并行。
+
+#### Dora IO Adapter
+
+负责：
+
+- 将 Gateway command queue 转为 `PolicyCommand` 输出。
+- 接收 `policy_command_status`、`runtime_status`、`proprio_state`、`action`、`record_status`、`playback_status`、`image/*` 等输入。
+- 将输入事件交给 Runtime State Aggregator。
+
+#### Runtime State Aggregator
+
+负责：
+
+- 根据事件更新 SessionState / CommandState / NodeStatus。
+- 处理 timeout。
+- 处理 result。
+- 维护 runtime readiness。
+
+#### Runtime Context Builder
+
+负责生成：
+
+- Agent 可读 runtime status。
+- capabilities。
+- active session。
+- current session summary。
+- last result。
+- failure reason。
+- environment summary。
+
+### 2.3 状态模型
+
+#### SessionState
+
+```json
+{
+  "session_id": "sess_...",
+  "status": "running",
+  "created_at": 1710000000.0,
+  "updated_at": 1710000001.0,
+  "action_type": "grasp",
+  "instruction": "抓取桌面上的红苹果",
+  "source": "paos-agent",
+  "target": "red_apple",
+  "command_ids": ["cmd_..."],
+  "message": ""
+}
+```
+
+状态：
+
+```text
+queued
+running
+succeeded
+failed
+cancelled
+```
+
+MVP+ 不实现复杂排队策略，也不允许通过配置开启并行。同一 robot 强制只允许一个 `queued/running` session。
+
+#### CommandState
+
+```json
+{
+  "command_id": "cmd_...",
+  "session_id": "sess_...",
+  "policy_id": "sam3",
+  "command": "grasp_simple",
+  "action_type": "grasp",
+  "inputs": {
+    "target_name": "red_apple",
+    "session_id": "sess_...",
+    "command_id": "cmd_...",
+    "policy_id": "sam3"
+  },
+  "status": "running",
+  "request_id": "cmd_...",
+  "created_at": 1710000000.0,
+  "updated_at": 1710000001.0,
+  "sent_at": 1710000000.2,
+  "message": "",
+  "outputs": {}
+}
+```
+
+状态：
+
+```text
+queued
+sent
+running
+succeeded
+failed
+cancelled
+```
+
+#### NodeStatus
+
+```json
+{
+  "node_id": "sam3_policy",
+  "node_type": "policy",
+  "status": "running",
+  "phase": "planning",
+  "updated_at": 1710000002.0,
+  "active_command_id": "cmd_...",
+  "last_error": null
+}
+```
+
+### 2.4 状态转换
+
+```text
+POST /agent/sessions
+  -> session created
+  -> command created
+  -> queued
+
+Gateway emits PolicyCommand
+  -> sent
+
+policy_command_status accepted/running
+  -> running
+
+policy_command_status done
+  -> succeeded
+
+policy_command_status rejected/error
+  -> failed
+
+cancel requested
+  -> cancelled
+  -> Gateway sends stop PolicyCommand to original policy
+```
+
+### 2.5 `execution_status` 与 `task_status`
+
+MVP+ 必须区分：
+
+```text
+execution_status:
+  policy command 是否完成
+
+task_status:
+  任务语义是否真正成功
+```
+
+原因：当前很多 policy 只能知道动作序列是否完成，无法判断真实任务是否成功。
+
+示例：
+
+```json
+{
+  "execution_status": "succeeded",
+  "task_status": "unknown",
+  "success": null,
+  "message": "policy sequence finished; task success is not verified"
+}
+```
+
+后续可通过 verifier / evaluator node 补齐 `task_status`。
+
+### 2.6 SAM3 Policy 改造要求
+
+`sam3_policy` 已按 MVP+ 协议做最小改造：
+
+1. 订阅 `policy_command`。
+2. 解析 `forge_msgs.PolicyCommand`。
+3. 将 `PolicyCommand.command` 映射到原业务动作 mode。
+4. 从 `PolicyCommand.inputs` 读取：
+   - `session_id`
+   - `command_id`
+   - `target`
+   - `target_name`
+   - `instruction`
+5. 保持原 `action` 输出。
+6. 输出 `policy_command_status`。
+
+`sam3_policy` 内部需要维护 policy-local state：
+
+```text
+current_session_id
+current_command_id
+current_mode
+current_phase
+last_command
+active_step
+step_queue
+started_at
+last_progress_at
+last_error
+```
+
+但不应维护全局 runtime state。
+
+### 2.7 Dora Topics
+
+#### Gateway 输出
+
+```text
+policy_command
+```
+
+#### Gateway 输入
+
+```text
+policy_command_status
+runtime_status
+proprio_state
+action
+record_status
+playback_status
+image/*
+```
+
+#### `policy_command_status`
+
+使用 `forge_msgs.PolicyCommandStatus`。
+
+```json
+{
+  "policy_id": "sam3",
+  "command": "grasp_simple",
+  "request_id": "cmd_...",
+  "status": "done",
+  "message": "",
+  "outputs_json": {
+    "accepted": true,
+    "command_id": "cmd_...",
+    "target_name": "red_apple"
+  }
+}
+```
+
+Gateway 优先用 `request_id` 关联 `CommandState`；`request_id` 为空时可尝试使用 `outputs.command_id`。
+
+### 2.8 Runtime Context
+
+Gateway 生成 `runtime_context.json`：
+
+```json
+{
+  "updated_at": 1710000000.0,
+  "capabilities": {
+    "api_version": "paos-forge-gateway-mvp-plus.v1",
+    "action_manifests": ["./actions/piper/sam3.md"],
+    "supports": {
+      "sessions": true,
+      "command_id": true,
+      "cancel": true,
+      "reset": true,
+      "estop": false,
+      "runtime_context": true,
+      "serial_actions_only": true
+    },
+    "policies": {
+      "sam3": {
+        "robot_id": "piper",
+        "actions": {
+          "grasp": {
+            "command": "grasp_simple",
+            "required_parameters": ["target_name"]
+          }
+        }
+      }
+    }
+  },
+  "readiness": {
+    "ready": true,
+    "missing": []
+  },
+  "active_session_id": "sess_...",
+  "sessions": {},
+  "commands": {},
+  "nodes": {},
+  "last_result": {},
+  "last_error": null,
+  "runtime": {
+    "current_frame_count": 100,
+    "sim_status": {},
+    "record_status": {},
+    "playback_status": {}
+  }
+}
+```
+
+MVP+ 中，PAOS Agent 通过 API 读取该 context；Markdown mirror 只是兼容和审计。
+
+### 2.9 Event Log
+
+Gateway 写 JSONL：
+
+```json
+{"ts":1710000000.0,"type":"session_created","data":{"session":{"session_id":"sess_..."},"command":{"command_id":"cmd_..."}}}
+{"ts":1710000000.2,"type":"command_sent","data":{"command_id":"cmd_..."}}
+{"ts":1710000012.4,"type":"policy_command_status","data":{"request_id":"cmd_...","status":"done"}}
+{"ts":1710000013.0,"type":"session_cancelled","data":{"session_id":"sess_..."}}
+```
+
+MVP+ 重启恢复策略：
+
+- Gateway 重启后加载 snapshot。
+- 不恢复未完成的低层 action；未完成 session 需要由上层重新查询或重新发起。
+- 不尝试恢复正在执行的低层 action。
+
+### 2.10 Watchdog MVP+ 范围
+
+MVP+ 做：
+
+- readiness
+- status aggregation
+- `policy_command_status` 状态回流
+- cancel/stop 上层控制
+- VLA/长动作的简单停止语义：Gateway 将 session 标记为 `cancelled`，并向原 policy 下发 `stop`
+
+MVP+ 不做：
+
+- 实时安全裁剪
+- 硬件 E-stop
+- LLM 介入实时控制
+- 自动 recovery
+- 可配置并行动作
+- VLA 任务完成自动判定
+
+后续中长期再做：
+
+- node heartbeat protocol
+- cancel acknowledgement
+- reset acknowledgement
+- estop dataflow
+- verifier/evaluator
+- Agent 任务级 retry/replan

--- a/docs/forge/paos_forge_fusion_design.md
+++ b/docs/forge/paos_forge_fusion_design.md
@@ -1,0 +1,10 @@
+# PAOS-Forge 融合设计文档
+
+本文档已拆分为四份独立设计文档，便于分别评审和维护：
+
+1. [PAOS-Forge 融合总体设计](paos_forge_overall_design.md)
+2. [Forge Gateway MVP+ 详细设计](forge_gateway_mvp_plus_design.md)
+3. [PAOS / Gateway / Forge 三方接口协议附录](paos_gateway_forge_protocols.md)
+4. [Forge Gateway Action Manifest 组织设计](forge_gateway_action_manifest_design.md)
+
+当前实现以 Forge 内置 Gateway 为控制面，使用 `/agent/*` API、`forge_msgs.PolicyCommand`、`forge_msgs.PolicyCommandStatus`、`./actions/{robot_id}/{policy_id}.md` action manifest、JSONL event log 和 `runtime_context.json` snapshot 形成闭环。后续更新请优先修改对应拆分文档。

--- a/docs/forge/paos_forge_overall_design.md
+++ b/docs/forge/paos_forge_overall_design.md
@@ -1,0 +1,250 @@
+# PAOS-Forge 融合总体设计
+
+### 1.1 背景与目标
+
+当前 PAOS preview 分支已经完成 Runtime v2 会话化改造，旧 `ACTION.md + hal_watchdog + policy_http` 链路已从主线移除。继续基于旧 `command_server` 或旧 HAL watchdog 做 PAOS-Forge 融合，会引入新的兼容层和重复 gateway。
+
+新的融合方向应直接以 Forge 内置 gateway 为 runtime 控制面，以 Forge Dora dataflow 作为执行层：
+
+```text
+PAOS Agent Layer
+  |
+  | /agent/* API
+  v
+Forge Gateway
+  |
+  | forge_msgs.PolicyCommand
+  v
+Forge Dataflow Execution Plane
+  |
+  +--> policy node
+  +--> task_robot
+  +--> robot / sim / sensor / recorder nodes
+  |
+  | policy_command_status / runtime_status / state
+  v
+Forge Gateway
+  |
+  | runtime context / result / lessons mirror
+  v
+PAOS Agent Layer
+```
+
+核心目标：
+
+- PAOS 不再维护底层 runtime execution model。
+- Forge Gateway 成为 Agent 和执行层之间的唯一稳定边界。
+- Forge dataflow 承担 policy、robot、sim、sensor、recorder、benchmark plugin 的执行。
+- PAOS Agent 只通过 command / context / result 协议与 Forge 交互。
+
+### 1.2 非目标
+
+MVP+ 阶段不做以下事项：
+
+- 不继续沿用旧 `ACTION.md + hal_watchdog + policy_http` 主链路。
+- 不将 PAOS Runtime v2 的 `TargetSessionHandle`、`BaseRolloutTarget`、`PerceptionRuntime`、`OpenPISkillRuntime` 原样迁入 Forge。
+- 不实现完整工业安全 watchdog 和硬件 E-stop。
+- 不实现 Game Agent。
+- 不实现 LIBERO / RoboCasa 等 benchmark 的具体 plugin，只定义规划接口。
+- 不引入数据库作为强一致状态存储。
+
+### 1.3 边界划分
+
+#### PAOS Agent Layer
+
+PAOS 保留：
+
+- 自然语言理解
+- Agent 工具选择
+- Critic / 任务前校验
+- 任务规划和重试决策
+- 对 runtime context 的理解
+- 任务后总结、lessons、memory 使用
+
+PAOS 不再负责：
+
+- target lifecycle
+- skill runtime loop
+- perception runtime loop
+- policy client lifecycle
+- robot/sim adapter execution
+- session runner / watchdog 执行
+
+#### Forge Gateway
+
+Forge Gateway 负责：
+
+- 提供 `/agent/*` API。
+- 分配 `session_id` 和 `command_id`。
+- 维护轻量 session / command 状态。
+- 从 `./actions/{robot_id}/{policy_id}.md` action manifest 解析可用动作。
+- 将 Agent action 转换为 `forge_msgs.PolicyCommand`。
+- 汇总 policy、robot、sim、sensor、recorder 的状态。
+- 生成 Agent 可读 runtime context。
+- 写出 JSONL 事件日志和 context snapshot。
+- 支持 session cancel，并向对应 policy 下发 `stop`。
+- 为后续 watchdog、reset、estop、benchmark API 预留接口。
+
+#### Forge Dataflow Execution Plane
+
+Forge dataflow 负责：
+
+- 执行 policy。
+- 输出 robot action。
+- 路由 `JointState` / `JointCommand`。
+- 执行真机或仿真。
+- 采集传感器数据。
+- 输出状态事件和结果事件。
+- 后续支持 recorder、benchmark plugin、verifier。
+
+### 1.4 对 PAOS Runtime v2 Session 的取舍
+
+PAOS Runtime v2 的 session 当前承担了多种职责：
+
+- 任务队列
+- target / skillruntime 绑定
+- policy / target endpoint 路由
+- 执行参数
+- 超时和重试
+- preflight
+- safety profile
+- result / lesson 写回
+
+Forge 替代 runtime 后，这些职责应拆分：
+
+| 原 PAOS Runtime v2 职责 | 新架构归属 |
+|---|---|
+| `session_id` / 任务描述 | Forge Gateway 轻量 session |
+| `target_ref` / `skillruntime_ref` | Forge action manifest / command mapping |
+| `policy_endpoint` / `target_endpoint` | Forge dataflow 配置 |
+| `max_steps` / `control_hz` / chunk 参数 | policy node / sim node / dataflow config |
+| preflight | Gateway readiness + 后续 capability check |
+| safety profile | Gateway safety policy + driver/node safety，MVP 只预留 |
+| result / lesson | Gateway result/context mirror，PAOS Agent 消费 |
+| `SessionRunner` | 不迁移，由 Forge dataflow 替代 |
+
+关键原则：
+
+```text
+保留 session 语义，不保留 PAOS Runtime v2 的 session 执行对象模型。
+```
+
+### 1.5 Game Agent 与 Benchmark
+
+#### Game Agent
+
+Game Agent 暂时作为独立 Agent 分支，不纳入 PAOS-Forge runtime 融合主线。
+
+Gateway 协议可以预留 `target_kind` 字段，但 MVP+ 不实现 `game` target。
+
+#### Benchmark
+
+Benchmark 采用规划设计，不进入 MVP+ 实现。
+
+推荐方向：
+
+```text
+Benchmark 框架作为外部 server 或 plugin node 接入 Forge。
+Forge core 提供 benchmark protocol、gateway API、result aggregator。
+具体 LIBERO / RoboCasa / Behavior 等接入在模块开发阶段细化。
+```
+
+MVP+ 只预留：
+
+- `/agent/benchmarks`
+- benchmark context schema
+- benchmark result schema
+
+### 1.6 分阶段改造重心
+
+#### Phase 0：协议冻结
+
+目标：PAOS、Gateway、Forge policy 可以并行开发。
+
+产出：
+
+- Agent Command Protocol
+- Runtime Feedback Protocol
+- Runtime Context Protocol
+- PolicyCommand 输入规范
+- `policy_command_status` 输出规范
+- action manifest 路径与字段规范
+
+#### Phase 1：Forge Gateway MVP+
+
+目标：基于 Forge 内置 gateway 增加 Agent-facing 能力。
+
+新增：
+
+- `/agent/sessions`
+- `/agent/sessions/{session_id}`
+- `/agent/runtime/status`
+- `/agent/runtime/context`
+- `/agent/runtime/capabilities`
+- 轻量 SessionState / CommandState
+- 内存状态表
+- JSONL 事件日志
+- `runtime_context.json` snapshot
+- `PolicyCommand` output
+- `PolicyCommandStatus` input
+- `./actions/{robot_id}/{policy_id}.md` manifest 解析
+- 同一 robot 强制串行执行 action
+
+#### Phase 2：SAM3 Policy 支持 `PolicyCommand`
+
+目标：抛弃旧 `command_server` 主线，让现有 SAM3 policy 对齐 Forge 标准协议。当前 MVP+ 已在 `sam3_grasp_runner` 中使用 `gateway/policy_command` 与 `sam3_policy/policy_command_status` 打通闭环。
+
+改造：
+
+- `sam3_policy` 订阅 `policy_command`。
+- 从 `PolicyCommand.command` 解析业务动作 mode。
+- 从 `PolicyCommand.inputs` 读取 `target_name`、`session_id`、`command_id`。
+- 保持原 `action` 输出不变。
+- 输出 `policy_command_status`。
+- `sam3_grasp_runner/dataflows/sim/sam3_dataflow_sim.yaml` 和 real dataflow 将 `sam3_policy/policy_command_status` 回连到 Gateway。
+
+#### Phase 3：Feedback 闭环
+
+目标：Gateway 能够基于 `PolicyCommandStatus.request_id` 维护 session 状态。
+
+新增：
+
+- `policy_command_status` 回流
+- `request_id == command_id` 关联
+- `accepted/running/done/rejected/error` 到 Gateway command/session 状态映射
+- runtime context 更新
+
+#### Phase 4：Context 镜像与 Agent 消费
+
+目标：PAOS Agent 可以稳定读取下层能力、状态、结果。
+
+新增：
+
+- `runtime_context.json`
+- 可选 `FORGE_RUNTIME.md`
+- 可选 `ENVIRONMENT.md` mirror
+- 可选 `LESSONS.md` append
+
+#### Phase 5：Watchdog 基础能力
+
+目标：非实时安全监督。
+
+新增：
+
+- readiness check
+- stale detection
+- node heartbeat
+- policy timeout
+- cancel 基础接口：Gateway 将目标 session 标记为 `cancelled`，并向原 policy 下发 `stop`
+- reset 基础接口
+- estop placeholder
+
+#### Phase 6：Benchmark Protocol
+
+目标：规划 benchmark server / plugin 接入，不实现具体 benchmark。
+
+新增：
+
+- `/agent/benchmarks`
+- benchmark job schema
+- benchmark status/result context

--- a/docs/forge/paos_gateway_forge_protocols.md
+++ b/docs/forge/paos_gateway_forge_protocols.md
@@ -1,0 +1,411 @@
+# PAOS / Gateway / Forge 三方接口协议附录
+
+### 3.1 协议分组
+
+三方并行开发依赖三组协议：
+
+1. **PAOS -> Gateway：Agent Command Protocol**
+2. **Gateway -> Forge：Runtime Command Protocol**
+3. **Forge -> Gateway：Runtime Feedback Protocol**
+
+### 3.2 PAOS -> Gateway：Agent Command Protocol
+
+#### 创建 Session
+
+```http
+POST /agent/sessions
+Content-Type: application/json
+```
+
+请求：
+
+```json
+{
+  "session_id": "optional-session-id",
+  "command_id": "optional-command-id",
+  "action_type": "grasp",
+  "target_name": "red_apple",
+  "instruction": "抓取桌面上的红苹果",
+  "source": "paos-agent",
+  "inputs": {
+    "auto_home": false
+  }
+}
+```
+
+响应：
+
+```json
+{
+  "ok": true,
+  "data": {
+    "session": {
+      "session_id": "sess_...",
+      "status": "queued",
+      "action_type": "grasp",
+      "command_ids": ["cmd_..."]
+    },
+    "command": {
+      "command_id": "cmd_...",
+      "policy_id": "sam3",
+      "command": "grasp_simple",
+      "request_id": "cmd_...",
+      "status": "queued"
+    },
+    "status": "queued"
+  }
+}
+```
+
+错误响应：
+
+```json
+{
+  "ok": false,
+  "msg": "missing required inputs: target_name"
+}
+```
+
+#### 查询 Session
+
+```http
+GET /agent/sessions/{session_id}
+```
+
+响应：
+
+```json
+{
+  "ok": true,
+  "data": {
+    "session": {
+      "session_id": "sess_...",
+      "status": "running",
+      "action_type": "grasp",
+      "command_ids": ["cmd_..."]
+    },
+    "commands": [
+      {
+        "command_id": "cmd_...",
+        "policy_id": "sam3",
+        "command": "grasp_simple",
+        "status": "running",
+        "outputs": {}
+      }
+    ]
+  }
+}
+```
+
+#### 取消 Session
+
+```http
+POST /agent/sessions/{session_id}/cancel
+```
+
+请求：
+
+```json
+{
+  "reason": "agent_requested"
+}
+```
+
+响应：
+
+```json
+{
+  "ok": true,
+  "data": {
+    "session_id": "sess_...",
+    "status": "cancelled"
+  }
+}
+```
+
+MVP+ 已实现最小 cancel 语义：Gateway 将 session/command 标记为 `cancelled`，并向原 `policy_id` 下发 `PolicyCommand(command="stop")`。该能力用于 VLA 或长动作的上层简单停止控制，不表示底层已经完成复杂恢复。
+
+#### Runtime Status
+
+```http
+GET /agent/runtime/status
+```
+
+响应：
+
+```json
+{
+  "ok": true,
+  "data": {
+    "readiness": {
+      "ready": true,
+      "missing": []
+    },
+    "active_session_id": null,
+    "sessions": {},
+    "commands": {},
+    "nodes": {},
+    "last_result": {},
+    "last_error": null
+  }
+}
+```
+
+#### Runtime Context
+
+```http
+GET /agent/runtime/context
+```
+
+响应：
+
+```json
+{
+  "ok": true,
+  "data": {
+    "updated_at": 1710000000.0,
+    "capabilities": {},
+    "readiness": {},
+    "active_session_id": null,
+    "sessions": {},
+    "commands": {},
+    "nodes": {},
+    "last_result": {},
+    "last_error": null,
+    "runtime": {}
+  }
+}
+```
+
+#### Runtime Capabilities
+
+```http
+GET /agent/runtime/capabilities
+```
+
+响应：
+
+```json
+{
+  "ok": true,
+  "data": {
+    "api_version": "paos-forge-gateway-mvp-plus.v1",
+    "action_manifests": ["./actions/piper/sam3.md"],
+    "supports": {
+      "sessions": true,
+      "command_id": true,
+      "cancel": true,
+      "reset": true,
+      "estop": false,
+      "runtime_context": true,
+      "serial_actions_only": true
+    },
+    "policies": {
+      "sam3": {
+        "policy_id": "sam3",
+        "robot_id": "piper",
+        "manifest": "./actions/piper/sam3.md",
+        "actions": {
+          "grasp": {
+            "command": "grasp_simple",
+            "required_parameters": ["target_name"]
+          }
+        }
+      }
+    },
+    "actions": {
+      "grasp": {
+        "policy_id": "sam3",
+        "robot_id": "piper",
+        "command": "grasp_simple",
+        "required_parameters": ["target_name"]
+      }
+    }
+  }
+}
+```
+
+### 3.3 Gateway -> Forge：Runtime Command Protocol
+
+Gateway 输出 `forge_msgs.PolicyCommand`。
+
+规范：
+
+```json
+{
+  "policy_id": "sam3",
+  "command": "grasp_simple",
+  "request_id": "cmd_...",
+  "inputs_json": {
+    "session_id": "sess_...",
+    "command_id": "cmd_...",
+    "action_type": "grasp",
+    "policy_id": "sam3",
+    "target": "red_apple",
+    "target_name": "red_apple",
+    "instruction": "抓取桌面上的红苹果",
+    "source": "paos-agent"
+  }
+}
+```
+
+映射来自 action manifest，例如 `./actions/piper/sam3.md`：
+
+| Agent `action_type` | `policy_id` | PolicyCommand `command` | Required inputs |
+|---|---|---|---|
+| `grasp` | `sam3` | `grasp_simple` | `target_name` |
+| `place` | `sam3` | `explore_and_place` | `target_name` |
+| `check_target` | `sam3` | `check_target` | `target_name` |
+| `go_home` | `sam3` | `go_standby` | none |
+
+取消时，Gateway 向原 policy 下发：
+
+```json
+{
+  "policy_id": "sam3",
+  "command": "stop",
+  "request_id": "cancel_cmd_...",
+  "inputs_json": {
+    "session_id": "sess_...",
+    "command_id": "cancel_cmd_...",
+    "cancelled_command_id": "cmd_...",
+    "source": "paos-agent",
+    "reason": "agent_cancel"
+  }
+}
+```
+
+### 3.4 Forge -> Gateway：Runtime Feedback Protocol
+
+#### `policy_command_status`
+
+由 policy node 输出，类型为 `forge_msgs.PolicyCommandStatus`。
+
+```json
+{
+  "policy_id": "sam3",
+  "command": "grasp_simple",
+  "request_id": "cmd_...",
+  "status": "done",
+  "message": "",
+  "outputs_json": {
+    "accepted": true,
+    "command_id": "cmd_...",
+    "target_name": "red_apple"
+  }
+}
+```
+
+字段说明：
+
+| 字段 | 说明 |
+|---|---|
+| `policy_id` | policy 节点标识 |
+| `command` | 被处理的 PolicyCommand command |
+| `request_id` | Gateway 下发的 request id，MVP+ 等于 `command_id` |
+| `status` | `accepted/running/done/rejected/error` |
+| `message` | Agent 可读摘要 |
+| `outputs_json` | policy 输出对象，可包含 `command_id`、`target_name`、`accepted` 等 |
+
+Gateway 状态映射：
+
+| PolicyCommandStatus `status` | Gateway command/session |
+|---|---|
+| `accepted` / `running` | `running` |
+| `done` | `succeeded` |
+| `rejected` / `error` | `failed` |
+
+### 3.5 Runtime Context Protocol
+
+`RuntimeContextV1`：
+
+```json
+{
+  "updated_at": 1710000000.0,
+  "capabilities": {
+    "api_version": "paos-forge-gateway-mvp-plus.v1",
+    "supports": {
+      "sessions": true,
+      "command_id": true,
+      "cancel": true,
+      "runtime_context": true,
+      "serial_actions_only": true
+    },
+    "policies": {},
+    "actions": {}
+  },
+  "readiness": {
+    "ready": true,
+    "missing": []
+  },
+  "active_session_id": null,
+  "sessions": {},
+  "commands": {},
+  "nodes": {},
+  "runtime": {
+    "current_frame_count": 0,
+    "sim_status": {},
+    "record_status": {},
+    "playback_status": {}
+  },
+  "last_result": null,
+  "last_error": null
+}
+```
+
+MVP+ 中，`capabilities` 来自 action manifest，`last_result` 来自最近一次 `PolicyCommandStatus`。Gateway 不判断复杂任务语义成功，VLA 或长动作完成判定由 PAOS Agent 或后续 verifier 处理。
+
+### 3.6 Benchmark Protocol 预留
+
+MVP+ 不实现具体 benchmark，只预留：
+
+```http
+POST /agent/benchmarks
+GET /agent/benchmarks/{benchmark_id}
+```
+
+请求草案：
+
+```json
+{
+  "suite": "libero_spatial",
+  "tasks": ["pick_up_the_black_bowl"],
+  "num_episodes": 50,
+  "policy": {
+    "policy_id": "pi0",
+    "endpoint": "optional"
+  }
+}
+```
+
+结果草案：
+
+```json
+{
+  "benchmark_id": "bench_...",
+  "status": "completed",
+  "metrics": {
+    "success_rate": 0.82,
+    "mean_steps": 73.4
+  },
+  "failure_summary": {
+    "timeout": 5,
+    "grasp_failed": 4
+  }
+}
+```
+
+### 3.7 错误码建议
+
+| 错误码 | 说明 |
+|---|---|
+| `RUNTIME_NOT_READY` | Forge runtime readiness 不满足 |
+| `UNSUPPORTED_ACTION` | Agent 请求的 action 不支持 |
+| `INVALID_PARAMETERS` | 参数缺失或类型错误 |
+| `RUNTIME_BUSY` | 当前只支持单 active session，runtime 忙 |
+| `COMMAND_TIMEOUT` | command 超时 |
+| `POLICY_FAILED` | policy node 内部失败 |
+| `PERCEPTION_FAILED` | 感知阶段失败 |
+| `PLANNING_FAILED` | 规划阶段失败 |
+| `EXECUTION_FAILED` | 执行动作失败 |
+| `TASK_NOT_VERIFIED` | 执行完成但任务成功未验证 |

--- a/scripts/run_runtime_watchdog.py
+++ b/scripts/run_runtime_watchdog.py
@@ -13,6 +13,8 @@ if str(ROOT) not in sys.path:
 
 from PhyAgentOS.runtime.watchdog.supervisor import WatchdogSupervisor
 
+REQUIRED_RUNTIME_FILES = ("TARGETS.md", "SKILLRUNTIME.md", "SESSIONS.md")
+
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run PhyAgentOS runtime v2 watchdog")
@@ -24,7 +26,19 @@ def main() -> int:
     parser.add_argument("--once", action="store_true", help="Run one polling pass and exit")
     args = parser.parse_args()
 
-    supervisor = WatchdogSupervisor(args.workspace, environment_workspace=args.environment_workspace)
+    workspace = Path(args.workspace).expanduser()
+    missing = [name for name in REQUIRED_RUNTIME_FILES if not (workspace / name).exists()]
+    if missing:
+        print(
+            "Runtime workspace is missing required files: "
+            + ", ".join(missing)
+            + "\nInitialize it first:\n"
+            + f"  python scripts/init_runtime_workspace.py --workspace {workspace}",
+            file=sys.stderr,
+        )
+        return 2
+
+    supervisor = WatchdogSupervisor(workspace, environment_workspace=args.environment_workspace)
     if args.once:
         return 0 if supervisor.run_once() else 1
 


### PR DESCRIPTION
## Summary

- Add a Phase 3 PAOS-to-Forge Gateway bridge.
- Route Gateway action sessions through `SESSIONS.md`, `WatchdogSupervisor`, and `GatewaySessionRunner`.
- Add Forge quick start docs, runtime templates, and action manifest design notes.

## What Changed

- Added `PhyAgentOS/runtime/gateway/` with HTTP client, session runner, and command adapter.
- Added `runtime_hints.gateway_action` and a minimal watchdog branch for `ForgeGatewayRuntime`.
- Added `forge_gateway` target, `forge_gateway_sam3` skillruntime, and runtime contract templates.
- Added `docs/forge` quick start and design docs for the current bridge and future adapter direction.

## Test Plan

- `pytest tests/test_gateway_runtime.py`
- `python -m compileall PhyAgentOS/runtime/gateway PhyAgentOS/runtime/watchdog/supervisor.py PhyAgentOS/runtime/workspace/manager.py tests/test_gateway_runtime.py`

## Notes

- Keeps PAOS Runtime v2 session queue as a compatibility path.
- Gateway `succeeded` is command-level success; physical success remains `task_status: not_verified`.
