### PR TITLE
skill runtime: bundle start.sh pre-hook, PAOS env injection, profile-…

### DIFF
--- a/PhyAgentOS/skill_runtime/installer.py
+++ b/PhyAgentOS/skill_runtime/installer.py
@@ -344,6 +344,15 @@ class SkillEnvironmentBuilder:
             },
             "entrypoints": sorted(required),
         }
+        # 环境镜像 = 节点锁 + profile 文件内容。profile 文件（dataflow 与配置）变化
+        # 必须触发重渲染：同版本重装 bundle 时，旧 digest 只覆盖节点锁会导致
+        # 渲染副本（dataflow）滞留旧内容、只有符号链接（其余配置）跟随新 bundle。
+        profile_files: dict[str, str] = {}
+        profile_parent = skill.bundle_root / profile.dataflow.parent
+        for source in sorted(profile_parent.iterdir()):
+            if source.is_file():
+                profile_files[source.name] = sha256_file(source)
+        lock_value["profile_files"] = profile_files
         encoded = json.dumps(
             lock_value, ensure_ascii=False, separators=(",", ":"), sort_keys=True
         ).encode()
@@ -381,6 +390,12 @@ class SkillEnvironmentBuilder:
                 rendered = source_dataflow.read_text(encoding="utf-8").replace(
                     "${FORGE_RUNTIME_BIN}", str((target / "bin").resolve())
                 ).replace("${PAOS_SKILL_ROOT}", str(skill.bundle_root))
+                # dora daemon 不向节点透传父进程环境：dataflow env 段是唯一可靠
+                # 注入通道，节点（如 kai0_policy 推导默认权重路径）依赖这两个变量。
+                rendered = (
+                    rendered.replace("${PAOS_SKILL_NAME}", skill.name)
+                    .replace("${PAOS_SKILL_VERSION}", skill.version)
+                )
                 (launch_profile / profile.dataflow.name).write_text(
                     rendered, encoding="utf-8"
                 )

--- a/PhyAgentOS/skill_runtime/manager.py
+++ b/PhyAgentOS/skill_runtime/manager.py
@@ -107,6 +107,7 @@ class RuntimeManager:
                 f"Gateway address {manifest.gateway_url} is already in use; "
                 "refusing to adopt an unmanaged runtime"
             )
+        self._run_start_hook(manifest, profile_name)
 
         starting = RuntimeState(
             skill_name=skill_name,
@@ -262,6 +263,32 @@ class RuntimeManager:
             raise RuntimeManagerError("rendered Skill dataflow is missing")
         return path
 
+    def _run_start_hook(self, skill: SkillManifest, profile_name: str) -> None:
+        """skill bundle 内置 start.sh pre-hook（如存在）：大资产下载等特殊启动步骤。
+
+        `paos skill start` 在 prepare/预检之后、dora 流程启动之前执行
+        <bundle>/start.sh <skill-name> <skill-version>。stdio 直通（不捕获输出，
+        继承调用方终端——start.sh 的交互 y/n 确认直接可见）。退出码 0 → 继续
+        内置流程；非 0 → 中止启动（此时尚未落 starting 状态，不污染状态机）。
+        bundle 不含 start.sh 的 skill 直接跳过（no-op）。
+        """
+        hook = skill.bundle_root / "start.sh"
+        if not hook.is_file():
+            return
+        self._log(
+            skill.name, f"running bundle start.sh hook (profile={profile_name})"
+        )
+        result = subprocess.run(
+            ["bash", str(hook), skill.name, skill.version],
+            check=False,
+        )
+        if result.returncode != 0:
+            raise RuntimeManagerError(
+                "bundle start.sh hook exited with code "
+                f"{result.returncode}; skill start aborted"
+            )
+        self._log(skill.name, "bundle start.sh hook completed")
+
     def _ensure_dora_up(
         self,
         skill: SkillManifest,
@@ -283,6 +310,8 @@ class RuntimeManager:
                     **profile.environment,
                     "FORGE_RUNTIME_BIN": str(binary_root),
                     "PAOS_SKILL_ROOT": str(skill.bundle_root),
+                    "PAOS_SKILL_NAME": skill.name,
+                    "PAOS_SKILL_VERSION": skill.version,
                 }
                 subprocess.Popen(
                     [dora, "up"],
@@ -316,6 +345,8 @@ class RuntimeManager:
             **profile.environment,
             "FORGE_RUNTIME_BIN": str(binary_root),
             "PAOS_SKILL_ROOT": str(skill.bundle_root),
+            "PAOS_SKILL_NAME": skill.name,
+            "PAOS_SKILL_VERSION": skill.version,
         }
         self.logs_root.mkdir(parents=True, exist_ok=True)
         launch_log = self.logs_root / f"{flow_name}-dora.log"

--- a/docs/forge/benchmark-skill-architecture.md
+++ b/docs/forge/benchmark-skill-architecture.md
@@ -1,254 +1,249 @@
-# Benchmark 类 Skill 目标架构:paos-gateway-policy_runner-benchmark(kai0-libero 适配)
+# Benchmark 类 Skill 架构:paos-gateway-policy-runner-benchmark(kai0-libero 适配)
 
-> 状态:本文档为**目标契约文档**,记录 benchmark 类 Skill 应该具有的架构。
-> 实现状态表见 §10;正文以目标形态描述,未实现项在状态表中标注。
-> 本文档不描述构建/发布的具体操作步骤,操作规范以现有技能开发与发布文档为准。
+> 状态:本文档为**已实现架构契约文档**(2026-08-29 E2E 全链验证通过,见 §10)。
+> 操作步骤类规范以技能开发与发布文档为准,本文只描述架构与契约。
+> 注意:skill 树内的部分 README 仍描述早期 Action 形态,以本文档为准(已知不一致,见 §11)。
 
 ## 1. 背景与目标
 
 kai0-libero 是「跑 LIBERO 仿真基准」的典型 benchmark 类 Skill。其旧形态由四个节点与
-约 780 行手写 wire adapter 组成:adapter 负责把 Tool 请求翻译成批次子流程,批次以子进程
+约 780 行手写 wire adapter 组成:adapter 把 Tool 请求翻译成批次子流程,批次以子进程
 dora run 启动,推理服务(openpi serve_policy)则完全游离在技能生命周期之外,由部署脚本
 手工拉起、手工清理。
 
-目标形态收敛为 **paos-gateway-policy_runner-benchmark** 三节点单流程:
+目标形态收敛为 **paos-gateway-policy-runner-benchmark** 三节点单流程:
 
-- **gateway** — 控制面枢纽。HTTP 侧的 Tool invoke/status/result/cancel/stop 与
-  forge_tool endpoint 协议在此汇合,语义分发(Query/Action/Session)与并发/租约管理
+- **gateway** — 控制面枢纽。HTTP 侧的 Tool invoke/status/result/stop 与
+  forge_tool endpoint 协议在此汇合,语义分发(Query/Session)与并发/租约管理
   全部内聚。
-- **policy_runner** — 推理服务的常驻生命周期所有者,注册为 **Session tool**
-  (attach-or-launch + 三段就绪门 + stop 释放 GPU)。
-- **benchmark** — 仿真基准的执行者,注册为 **Action tool**(校验 → 进程内批次执行 →
-  进度事件 → 七字段终态结果,cancel 给部分结果)。
+- **policy-runner**(kai0_policy)— 推理服务的常驻生命周期所有者,注册为
+  **Session tool**(attach-or-launch + 三段就绪门 + stop 释放 GPU)。
+- **benchmark**(libero_benchmark)— 仿真基准的执行者,`benchmark.controller`
+  上挂 **describe(query)+ run(session)** 两个操作:**一个 session = 一个批次**,
+  stop 在 episode 边界落停,已完成集作 partial 结果。
 
 本轮适配性结论:
 
-- benchmark 用 Action 语义表达是**天然成立**的:单次批次是一次有界的、可取消的、
-  有明确终态结果的执行,这正是 Action 的契约;本轮只需把既有批次执行逻辑包进
-  ActionToolEndpoint,并把批次流程从子 flow 收回进程内。
-- policy_runner 用 Session 语义表达**要求全链新能力**:session 在 forge 协议层、
-  网关层两端此前均未实现(handler 对 session dispatch 抛 NotImplementedError,
-  gateway 目录拒绝 session 注册)。本轮补齐两端后,推理服务生命周期被纳入 Tool
-  生命周期,openpi 不再是无主的旁路进程。
-- 节点单独落库:benchmark 与 policy_runner 的代码、构建、测试归属各自节点仓库,
-  Skill 只保留锁与配置文件;最终交付物只有 skill bundle(含大模型权重)。
+- benchmark 用 **Session** 语义表达:批次执行时长不可估(episode 数与单步上限是
+  上界,真实耗时随策略行为漂移),且 stop 在 episode 边界优雅停、保留部分结果的
+  语义与 Session 的 stopping→stopped 相位一一对应;Action 的 deadline/cancel 模型
+  反而装不下「边界停 + partial 保留」的契约。
+- policy-runner 用 Session 语义表达:常驻推理服务、跨批复用、stop 释放 GPU,
+  与 Session 的无 deadline、stop 唯一终止、状态可查询契约一一对应。
+- 节点单独落库:benchmark 与 policy-runner 的代码、构建、测试归属各自节点仓库,
+  Skill 只保留锁与配置;最终交付物只有 skill bundle(权重不进 bundle,见 §8)。
 
 ## 2. 总体架构
 
-```
-                        ┌─────────────────────────────┐
-   上游 agent(HTTP) ───►│  gateway(控制面)             │
-   invoke/status/result/│  ├─ 语义分发 query/action/   │
-   cancel/stop          │  │   session                 │
-                        │  ├─ ToolSpec/目录/租约       │
-                        │  ├─ 并发与 deadline 管理     │
-                        │  └─ SSE 事件回放             │
-                        └──┬───────────┬──────────────┘
-                 tool 消息  │           │ tool 消息
-        (endpoint.register/ │           │ (endpoint.register/
-         invoke/status/     │           │  invoke/status/
-         result/control/    │           │  result/control/
-         event)             │           │  event)
-   ┌────────────────────────┴─┐   ┌─────┴───────────────────────┐
-   │ benchmark(ActionTool)    │   │ policy_runner(SessionTool)   │
-   │  run/cancel/status/result│   │  serve/stop/status/result    │
-   │  进程内批次执行            │   │  attach-or-launch + 就绪门   │
-   └──────┬───────────────▲───┘   └──────┬───────────────▲───────┘
-   proprio_state/image/ │ action       policy_command/ │ 推理请求
-   policy_command       │              proprio_state/  │ (WS)
-          │             │              image           │
-          └──── dora 数据面通道(单 MAIN flow)───────────┘
+```mermaid
+flowchart TB
+    subgraph AGENT[上游 agent(HTTP)]
+        A1[POST /tools/&#123;tool_id&#125;:invoke]
+        A2[POST /tools/&#123;endpoint&#125;/&#123;op&#125;:invoke]
+        A3[GET /invocations/&#123;id&#125;|/result|/events]
+        A4[POST /invocations/&#123;id&#125;/stop]
+    end
+
+    subgraph GW[gateway 控制面]
+        G1[语义分发 query / session]
+        G2[ToolSpec / 目录 / 租约]
+        G3[并发栅栏 + deadline 豁免]
+        G4[stop 簿记 + SSE 事件回放]
+    end
+
+    subgraph BM[libero_benchmark]
+        B1[benchmark.controller]
+        B2[describe query:进程内能力白名单]
+        B3[run session:一批次一 session]
+        B4[runner:episode 边界 stop 消费点]
+    end
+
+    subgraph PR[kai0_policy]
+        P1[policy.runner serve session]
+        P2[attach-or-launch + 三段就绪门]
+        P3[常驻推理服务]
+        P4[stop 释放 GPU]
+    end
+
+    A1 --> G1
+    A2 --> G1
+    A3 --> G2
+    A4 --> G4
+    G1 <-->|tool 协议 over dora| BM
+    G1 <-->|tool 协议 over dora| PR
+    B3 <-->|proprio_state / image / action| P3
+    B3 -->|policy_command| P3
 ```
 
 - **控制面**:上游 agent 只走 gateway 的 HTTP 接口与 forge_tool 协议;节点侧通过
   ToolEndpointHandler + DoraToolEndpointBinding 把协议消息架在 dora 通道上,与数据面
-  共存于同一 MAIN flow。三个节点常驻,无子 flow、无子进程 dora、无手写 adapter。
-- **数据面**:benchmark ↔ policy_runner 之间的 proprio_state/image/policy_command/action
+  共存于同一 MAIN flow。三节点常驻,无子 flow、无子进程 dora、无手写 adapter。
+- **数据面**:benchmark ↔ policy-runner 之间的 proprio_state/image/policy_command/action
   通道语义与旧形态完全一致(7 维 action、8 维 state、双相机 alias、execute_action_steps=5)。
 - **通道可靠性**:dora 0.4.1 存在突发丢包缺陷,tool_in/tool_out/policy_command 三个
   易突发通道必须显式 `queue_size: 32`;丢一条 register 续约会触发租约过期误判、丢一条
   tool.event 会破坏 event 序列连续性,因此该参数不可回落默认值。
 
-## 3. 会话工具与推理服务生命周期
+## 3. 会话工具一:benchmark.controller(describe + run)
 
-policy_runner 的 serve 操作是一个**常驻推理服务会话**:
+`benchmark.controller` 同时挂两个操作:
+
+- **describe(query,mc=1)**:进程内直读能力白名单,永不等待。返回 10 个 task 的
+  语言指令、每个 task 50 个 init state、关节名 joint1-7+gripper、默认
+  max_steps=300 / num_runs=1 / seed=0。Agent 据此组批。
+- **run(session,stoppable=True,status_supported=True,max_concurrency=1,
+  cancellable=False)**:一个 session = 一个批次。start 只登记(ToolAccepted 立即
+  返回,阻塞的 episode reset 由节点循环在 tool 分发之外执行,不拖慢握手);
+  忙/异参冲突/同参幂等按 forge_tool 会话契约处理。
+
+**stop 语义(核心契约)**:
+
+- stop 置位 `stop_requested` 标志,当前 episode **跑完**,在 episode 边界落停,
+  已完成集保留为 partial 结果。中途掐掉当前集会被判为数据污染,绝不做。
+- 相位推进:accepted →(stop 收下)→ stopping →(边界)→ stopped。
+- 已知边界情况:stop 落在**最后一个** episode 期间时,批次以 succeeded 收尾
+  (计划跑完先于 stop 检查——episode 已全部完成,无 partial 可言,行为可辩护)。
+- 节点被 dora STOP/ERROR 时,在跑 session 立即收成终态(不等边界),partial 输出。
+
+## 4. 会话工具二:policy.runner(serve)
+
+policy-runner 的 serve 操作是一个**常驻推理服务会话**:
 
 - **attach-or-launch**:start 先探测 `GET /healthz`;200 则附接(owned=false,不启动、
-  不击杀任何进程);否则以 `scripts/start_server.sh --ckpt <bundle 权重目录>
+  不击杀任何进程);否则以 `scripts/start_server.sh --ckpt <权重目录>
   --policy-config pi05_libero` 启动(owned=true,进程组记录,日志落会话工作区)。
 - **三段就绪门**(顺序执行,任一段失败即整体失败):
   1. `/healthz` 200(默认超时 600s);
   2. `infer-once` 成功且 `action_dim=7`;
-  3. norm_stats 文件 sha256 等于声明值 `b3a44bb2810436fb62917decaea58bd4d9110255df527dea21e8fd40c960bd84`。
+  3. norm_stats 文件 sha256 等于声明值 `b3a44bb2810436fb62917decaea58bd4d9110255df527dea21e8fd40c960bd84`
+     (pi05_libero 官方 norm_stats.json,权重目录 assets/ 下递归 glob 定位)。
   全部通过才返回 ToolAccepted(details 含 server_url/pid/owned/readiness)。
   失败时 owned 进程被 teardown,start 报 `READINESS_FAIL`(可重试)——环境不修复,
   盲目重试无意义。重复 start 幂等返回当前会话状态,绝不重启。
-- **跨批次复用**:就绪会话服务该运行时的所有批次;每次批次前不重启推理服务,
-  这是与旧形态(每批手工拉起/清理)的本质差别。
-- **stop 是唯一终止路径**:session 在网关侧不设 deadline(见 §4),永远只有 stop 能
+- **跨批次复用**:就绪会话服务该运行时的所有批次;每次批次前不重启推理服务。
+- **stop 是唯一终止路径**:session 在网关侧不设 deadline(见 §5),永远只有 stop 能
   终结它。owned 会话 teardown = SIGTERM 进程组 → 30s 宽限 → SIGKILL(GPU 释放 =
-  进程组消亡,可选 nvidia-smi 复核);attached 会话只标记 stopped,不杀进程。
-  对已 stopped 会话再 stop 从记录直接回答。
-- **未来 VLA 展望**:同一 SessionToolEndpoint 形态可承载「VLA 模型生成 action 支持
-  机器人工作」的场景——常驻推理服务、就绪门、stop 释放 GPU 的语义与机器人边
-  inference 边执行的需求同构;届时仅需替换服务启动方式与就绪判据,协议与网关层零改动。
+  进程组消亡);attached 会话只标记 stopped,不杀进程。对已 stopped 会话再 stop
+  从记录直接回答。实测 stop 链路:requested → accepted → stopped,结果
+  ToolResult.status=stopped、outputs 含 owned/pid/server_url,GPU 显存回落基线。
 
-## 4. 网关会话支持
+## 5. 网关会话支持
 
 - **注册与校验**:ToolSpec/目录白名单从 query|action 放宽到 query|action|session;
   未知语义仍在模型构造层拒绝。
-- **HTTP 接口**:`POST /tools/{tool_id}:invoke` 对 action|session 同走保留式提交
-  (202 + invocation_id);新增 `POST /invocations/{id}/stop`(镜像 cancel 路由)。
-  status/result/events 路由语义无关,原样复用。
+- **HTTP 接口**:`POST /tools/{tool_id}:invoke` 对 session 保留式提交
+  (202 + invocation_id);query 走 `POST /tools/{endpoint_id}/{operation}:invoke`;新增
+  `POST /invocations/{id}/stop`。status/result/events 路由语义无关,原样复用。
 - **deadline 豁免**:session invocation 提交时 `deadline_ms=None`,快照不含 deadline;
-  超时巡检只标记非 None 项——同一时钟下 action 会被标 unknown 而 session 不受影响。
-  单次握手/查询交换仍有界(invoke_timeout 约束)。session 寿命无界是设计决策:
-  常驻服务本就没有「批次时长」可估,per-tool 超时覆盖记入未来工作。
+  超时巡检只标记非 None 项。单次握手/查询交换仍有界(invoke_timeout 约束)。
+  session 寿命无界是设计决策:常驻服务本就没有「批次时长」可估。
 - **租约 unknown 语义**:provider 死亡由租约过期 → `mark_instance_ambiguous` 捕获,
-  这是 session 中途 provider 失联的唯一探测路径(会话不再被 deadline 扫为 unknown)。
+  这是 session 中途 provider 失联的唯一探测路径。benchmark 侧租约 TTL 需 120s:
+  进程内循环在 episode reset 期间阻塞数十秒不续租,短 TTL 会触发租约过期误判。
 - **stop 簿记**:stop 请求不改变相位——相位始终由 provider 的终态事件与结果驱动;
-  网关侧仅镜像 cancel 的三处簿记(stop_status: requested / accepted /
-  transport_error / terminal)。stop 到达 provider 后由 `stopped` 终态事件推进相位、
-  释放并发栅栏。
-- **控制命令语义域**:cancel 只对 Action 生效,stop 只对 Session 生效;跨语义请求
-  两端(forge handler 与网关)一律回答 unsupported,不静默、不降级。
+  网关侧簿记 stop_status(requested / accepted / terminal / unsupported)。stop 控制
+  载荷固定为 `{"command": "stop"}`(不携带 reason),stop 到达 provider 后由
+  `stopped` 终态事件推进相位、释放并发栅栏。
 
-## 5. 动作工具:基准测试
+## 6. 七字段结果契约
 
-benchmark 节点实现 ActionToolEndpoint(descriptor:run / action / cancellable /
-status_supported / max_concurrency=1):
+ToolResult 恒为七字段,与 skill 树 gateway.yaml 的 output_schema 一一对应
+(多一个少一个都会让下游 schema 校验失败):
 
-- **参数校验**:严格按 gateway schema 校验(suite 枚举、task_ids 0-9 且 ≤10 项、
-  init_state_ids 0-49 且 ≤50 项、num_runs≤5、max_steps≤1000、seed、未知 key 拒绝),
-  拒绝即回 INVALID_ARGUMENTS;随后以 invoke 参数覆盖 profile 静态默认,
-  `resolve_and_validate_plan` fail-fast(含单批次 ≤500 episode 硬上限)。
-- **进程内执行**:批次驱动逻辑并入 endpoint,以 asyncio 任务在节点常驻事件循环中
-  执行(不再渲染模板、不再启动子 flow);episode 300s / 批次 21600s 的 watchdog 变为
-  进程内 asyncio 定时器。重复 execution key 同参数幂等,异参数
-  FORGE_EXECUTION_CONFLICT,忙时 BUSY(retryable,details 附活跃 run_id);未知 key 的
-  status 直接以 FORGE_EXECUTION_NOT_FOUND 拒绝(provider 不伪造终态相位)。
-- **进度事件**:每 episode 完成发 progress 事件,叠加既有 benchmark_status 数据面流。
-- **取消 = 部分结果**:cancel 置进程内标志,当前 episode 边界优雅停,已完成 episode
-  保留为部分结果,cancelled/partial 终态 + result_file 保留。
-- **七字段契约**:ToolResult 恒为七字段(run_id / status(succeeded|failed|cancelled|
-  partial)/ completed_episodes / total_episodes / success_rate / result_file /
-  failure_summary),schema `benchmark_execution_result_v1` 与旧形态逐字不变——下游
+```text
+run_id / status / completed_episodes / total_episodes /
+success_rate / result_file / failure_summary
+```
+
+- **outputs.status 枚举**(给 Agent 看的批次结论):
+  `succeeded` | `failed` | `partial`(stop 后已完成集 >0)| `stopped`(一集没跑完)。
+- **ToolResult.status**(forge 执行结论)只能是 `succeeded` | `failed` | `stopped`:
+  批次被 stop 时两者分叉——outputs.status=partial/stopped 而 ToolResult.status=stopped;
+  failed 批次带 ToolError。
+- **failure_summary**:stop 批次由 `stopped_summary` 生成,形如
+  `stopped after 4/5 episodes`(网关 stop 载荷不带 reason,故无原因后缀)。
+- 落盘 schema `benchmark_execution_result_v1` 与旧形态逐字不变——下游
   verify_result 校验脚本无需改动。
-
-## 6. 三语义对比与选型
-
-| 能力 | query | action | session |
-| --- | --- | --- | --- |
-| 执行模型 | 同步一问一答 | 异步有界执行 | 常驻、无界生命周期 |
-| 准入 | 即时阻塞 | 202 + 并发栅栏 | 202 + 并发栅栏(无 deadline) |
-| 控制 | 无 | cancel | stop |
-| 终态 | 即终 | completed/failed/cancelled/unknown | stopped(provider 死亡 → unknown) |
-| 状态/结果查询 | 无 | 有 | 有 |
-
-**benchmark = Action 的四点理由**:
-
-1. 批次天然有界:episode 数与单步上限确定,执行时长可估,契合 Action 的 deadline 模型;
-2. 取消语义清晰:中止批次 = 停止当前 episode、保留部分结果,恰是 Action cancel 契约;
-3. 终态结果即交付物:七字段结果是调用方唯一关心物,契合「result 只查询一次」模型;
-4. 并发上限明确:单批次独占仿真器(max_concurrency=1),Action 的并发栅栏原样表达。
-
-**policy_runner = Session 的理由**:推理服务是跨批次常驻资源,其生命周期(拉起、
-就绪、复用、释放)远超单次执行边界;无界 + stop 唯一终止 + 状态可查询的 Session
-契约与之一一对应。若硬套 Action,每个批次都要背负一次「启动 + 就绪门 + teardown」,
-既无 deadline 可设,又丢失跨批次复用收益。
 
 ## 7. 技能打包与锁定
 
 - **锁契约**:`artifact_type: executable_tar_gz` + `entrypoint` + `sha256`(GitHub
-  Release digest),tar 根目录仅含 entrypoint 单二进制;安装器逐条校验
-  (sha256 必须为 64 位小写 hex)。
-- **节点构建下放 node 仓**:PyInstaller spec、构建脚本、entry shim 全部归属节点仓库
-  (benchmark / policy_runner 各自 build 目录);Skill 只保留锁与配置。构建脚本内以
+  Release digest),tar 根目录仅含 entrypoint 单二进制;安装器逐条校验。
+- **节点构建下放 node 仓**:PyInstaller spec、构建脚本归属节点仓库;构建脚本内以
   `tar -tzf` 断言单 entrypoint,失败即发布阻断。
-- **权重进 bundle**:π0.5-libero 权重(~12.4GB,params/ + assets/ 布局)在打包时位于
-  skill 源目录暂存位(gitignored),`package_skill.py` 的 archive-manifest 逐文件
-  SHA-256 覆盖之;权重不进入任何代码仓库,运行时由 bundle 解包位置注入
-  (session 配置 `weights_dir` 相对 bundle 根,start args 可覆盖)。
-- **本地 registry 覆盖**:`PAOS_RESOURCE_REGISTRY_URL` 指向本地服务,提供
-  `/v1/forge-nodes/<artifact_id>` → `{download_url, artifact_id, mode: direct}` 与
-  `/assets/*.tar.gz` 静态文件,即可用 `paos skill install <bundle> --yes` 完成闭环。
-- **不可变性**:已发布资产(Release asset / TOS 对象键 / artifact_id / digest)一律
-  不覆盖;gateway 因新增 session 能力重建为新版本 1.1.0(不复用 1.0.2 的
-  artifact_id 与 digest)。正式 registry 登记与公开 release 管线属维护者后续工作,
-  本地 E2E digest 不回写正式 registry。
+- **registry 登记**:nodes.yaml 已登记三个 artifact_id(gateway-1.1.0-linux-x86_64、
+  libero_benchmark-1.0.0-linux-x86_64、kai0_policy-1.0.2-linux-x86_64,均为公开
+  GitHub Release 直链)。
+- **不可变性**:已发布资产(Release asset / artifact_id / digest)一律不覆盖;
+  gateway 因新增 session 能力重建为新版本 1.1.0(不复用 1.0.2 的 artifact_id)。
 
-## 8. 外部服务与环境边界
+## 8. 权重交付:start.sh 预钩
+
+权重(~12.4GB)**不进 bundle**:
+
+- bundle 携带 `start.sh`,由 `paos skill start` 预钩调用:校验/下载权重到
+  `~/.PhyAgentOS/cache/weights/<skill>/<version>/`(源为 openpi 官方公开 GCS
+  权重,按 sha256 校验),失败即启动中止。
+- **交互确认**:y/n 确认后才下载;非 TTY 下 `read -t 30` 默认 N,
+  `PAOS_ASSUME_YES=1` 提供免交互出口。
+- 权重按 skill+version 缓存,重复 start 跳过下载;三个节点二进制仍走
+  registry 直链下载(§7)。
+
+## 9. 外部服务与环境边界
 
 - **openpi 生命周期归 session**:serve_policy 进程不再是部署脚本的手工产物,而是
   `kai0_libero.policy` session 的 owned 资源(attach-or-launch + stop teardown)。
 - **conda 仿真环境归 benchmark node 仓**:LIBERO 运行所需的 python 环境由节点仓库
   的构建/安装步骤准备,Skill 不携带环境。
 - **LIBERO 资产归 node 仓**:仿真资产与官方数据集属节点仓库部署范畴,bundle 不含。
-- **推理运行时归 policy_runner node 仓**:server venv(python3.12 + jax)由节点仓库
+- **推理运行时归 policy-runner node 仓**:server venv(python3.12 + jax)由节点仓库
   setup 脚本安装,start_server.sh 是其唯一入口。
-- **GPU ≥16GB 为硬件前置**:π0.5-libero 推理的内存基线;无 GPU 环境表现为
-  READINESS_FAIL(快速失败,不挂起)。
-- **bundle 体积**:12.4GB 权重使安装变慢(可接受),文档在此注明;TOS 上传由维护者
-  手工完成,对象键不覆盖。
+- **GPU ≥16GB 为硬件前置**:无 GPU 环境表现为 READINESS_FAIL(快速失败,不挂起)。
 
-## 9. 端到端验证
+## 10. 端到端验证(2026-08-29 全链通过)
 
-分层矩阵(联网命令一律去除代理变量):
-
-| 层 | 内容 | 门控 |
+| 层 | 内容 | 结果 |
 | --- | --- | --- |
-| L0 | 各仓单元/契约测试:forge session dispatch 套件、gateway 翻转+session 流+deadline 豁免、benchmark endpoint 契约、policy_runner 会话测试 | 无 GPU |
-| L1 | gateway HTTP session API:register→invoke→202→accepted→stop→stopped→result;重复 start 幂等;deadline 豁免;租约过期→unknown | 无 GPU |
-| L2 | benchmark action:gateway + benchmark 二进制 + 恒值 7 维 action 桩;1-episode 计划 202→accepted→SSE 进度→七字段终态;取消→cancelled/partial + result_file | conda 仿真环境 |
-| L3 | session 生命周期:A 附接(预起服务→owned=false)/ B 拉起(owned=true)/ C 复用(真实批次跨批不重启)/ D stop(owned 时 nvidia-smi 无残留)/ E 无 GPU 无服务→快速 READINESS_FAIL | GPU |
-| L4 | 打包闭环:三二进制单 entrypoint 断言→权重注入打包→本地 registry 覆盖→`paos skill install --yes`→解包布局/entrypoint 可执行/权重在位→dora 3 节点流启动→结果符合 benchmark_execution_result_v1→queue_size=32 下租约不丢 | 无 GPU;权重注入与真 libero 二进制待环境 |
+| L0 | 各仓单元/契约测试(forge session dispatch、gateway session 流、benchmark endpoint 契约、policy 会话) | 全绿 |
+| L1 | gateway HTTP session API(register→invoke→202→accepted→stop→stopped→result;deadline 豁免) | 通过 |
+| L2 | policy 会话就绪门:healthz→infer-once(action_dim=7)→norm_stats 递归 glob 锚点 | 通过(kai0_policy 1.0.2 二进制) |
+| L3 | describe 查询:能力白名单(10 task / 50 init state / joints / defaults) | 通过 |
+| L4 | run 批次:1/2/3 episode 批次 succeeded,七字段终态,~60ms/步 | 通过 |
+| L5 | stop 全链路:requested→accepted→stopping→stopped;partial 4/5 与 2/3;终态 stop 正确回 terminal;failure_summary 生成 | 通过 |
+| L6 | policy session stop:owned teardown,GPU 显存回落,进程组消亡 | 通过 |
+| L7 | `paos skill stop kai0-libero`:三节点优雅退出,gateway 下线 | 通过 |
+| L8 | 发布闭环:gateway 1.1.0 / libero_benchmark 1.0.0 / kai0_policy 1.0.2 三资产公开;nodes.yaml 三条目登记推送 | 完成 |
 
-环境缺失的层降级为 fake/stub 单测并标注 env-gated,不伪造通过。
+skill bundle(kai0-libero 1.0.0)已打包并登记:skills.yaml 采用相对
+object_key(`skill-bundles/kai0-libero/1.0.0/kai0-libero-1.0.0.tar.gz`,
+sha256 7706ffa8…,19512 bytes),bucket 由部署配置 TOS_BUCKET 决定
+(现为私有桶 phyagentos-resource-inner)。
 
-## 10. 实现状态表
+## 11. 实现状态表
 
 | 项 | 状态 |
 | --- | --- |
-| forge handler session dispatch(含语义域控制) | 已实现并发布(forge-tool-v0.2.0 tag 已推 gitlab dev) |
-| gateway session spec 校验、stop 路由、deadline 豁免、stop 簿记 | 已实现(feat/tool-session → 1.1.0) |
-| benchmark ActionToolEndpoint(libero) | 已实现(真实二进制待 conda 环境构建) |
-| policy_runner SessionToolEndpoint(kai0_runner) | 已实现(二进制需按 SPECPATH 修复重建,旧 digest 过期) |
-| kai0-libero skill 3 节点迁移(双工具 + 新锁契约) | 本轮实现 |
-| bundle 交付(含权重,本地 registry 闭环) | registry 闭环已验(libero 暂以占位 shim 走通安装契约);权重注入待用户暂存权重后打包 |
-| E2E L0-L1 | 通过(各仓测试全绿;gateway HTTP session 流含 stop/并发释放/deadline 豁免) |
-| E2E L2-L3 | 环境门控(conda 仿真环境 / GPU 与权重未就绪),不伪造通过 |
-| E2E L4 | 机制闭环通过(三节点下载→sha256 校验→单 entrypoint 解包→可执行);dora 3 节点全流与权重在位待环境 |
-| registry 正式登记 nodes.yaml/skills.yaml | 未来(维护者) |
-| 公开 release 管线(GitHub Release / TOS 上传) | 未来(维护者,手工) |
-| 上游 agent 的 session 桥接工具(PAOS agent 层) | 未来 |
-| 多会话并发 / per-tool 超时覆盖 / VLA 场景 | 未来 |
+| forge handler session dispatch(含语义域控制) | 已实现并发布 |
+| gateway session spec 校验、stop 路由、deadline 豁免、stop 簿记 | 已实现(v1.1.0,已发布) |
+| libero_benchmark benchmark.controller(describe query + run session + 边界 stop) | 已实现并发布(v1.0.0) |
+| kai0_policy policy.runner serve session(attach-or-launch + 就绪门 + stop 释放 GPU) | 已实现并发布(v1.0.2) |
+| kai0-libero skill 三节点迁移(双 Session 工具 + 新锁契约) | 完成(bundle 1.0.0 已打包) |
+| start.sh 权重预钩(paos skill start) | 完成(PhyAgentOS feature/forge) |
+| nodes.yaml 三条目 registry 登记 | 已提交并推送(dev) |
+| skills.yaml 正式登记 | 已提交并推送(dev d31e0df;私有桶 phyagentos-resource-inner + 相对 object_key) |
+| skill 树 README 与本文档的一致性 | 已知不一致:README 仍描述早期 Action 形态,暂不改动(按约束) |
 
-### 10.1 下一步:测试线与发布收尾(2026-08-27)
-
-forge-tool-v0.2.0 已正式发布;forge 分支治理同步完成(master 合并进 dev,以 master 为准,dev 仅保留本轮 tool 相关内容)。剩余工作按依赖排序:
-
-| # | 工作 | 依赖 | 环境门槛 |
-| --- | --- | --- | --- |
-| 0a | gateway vendored forge_tool 对齐 v0.2.0(dora.py 存在差异);对齐后重建 gateway 1.1.0 二进制、更新 sha256 | — | 无 |
-| 0b | kai0_policy 二进制重建(SPECPATH 修复 317533a 之后,旧 digest 过期)并重取 sha256 | — | 无 |
-| 1 | libero 真实二进制构建(make_node_bundle.sh + 单 entrypoint 断言 + sha256) | conda LIBERO 环境 | 环境门控 |
-| 2 | libero 契约单测(tests/test_contracts.py,conda 环境内) | 1 | 环境门控 |
-| 3 | libero/kai0_runner 锁刷新(rev=forge-tool-v0.2.0 已可解析;uv.lock 固化旧 sha 则重锁) | — | 无 |
-| 4 | skill.yaml 三节点锁回填(artifact_id / entrypoint / sha256 = 正式 Release digest) | 0a / 0b / 1 | 无 |
-| 5 | L2 benchmark action E2E(gateway + libero 二进制 + 恒值 7 维 stub;202→accepted→SSE 进度→七字段终态;cancel→cancelled/partial) | 0a / 1 | conda libero-bench |
-| 6 | L4 打包闭环(权重注入→打包→本地 registry 覆盖→install→dora 3 节点流→结果契约→queue_size=32 租约不丢) | 4 + 权重 12.4GB | 权重下载 |
-| 7 | L3 session 生命周期(A 附接 / B 拉起 / C 跨批复用 / D stop+GPU 释放 / E 无 GPU 快速失败) | 0b / 6 | GPU |
-
-## 11. 风险与限制
+## 12. 风险与限制
 
 1. **外置 provider 租约语义**:provider 死亡探测依赖租约过期 → unknown(歧义语义),
    调用方需 reconcile 而非盲目重跑;session 中途失联同样只此一条路径。
-2. **GPU 前置**:无 GPU 即 READINESS_FAIL,快速失败不挂起;但 GPU 归属争用
+2. **GPU 前置**:无 GPU 即 READINESS_FAIL,快速失败不挂起;GPU 归属争用
    (他方占用 / 多会话并发)本轮未治理。
-3. **bundle 体积**:12.4GB 权重使安装/分发变慢;增量分发与资产拆分留待未来。
+3. **权重体积**:12.4GB 权重按 skill+version 缓存,首次 start 下载耗时可观;
+   增量分发留待未来。
 4. **dora 队列约束**:queue_size=32 是 0.4.1 缺陷的实测止血参数,依赖 dora 版本
    行为;升级 dora 后需回归验证突发通道。
 5. **vendored 协议层漂移**:gateway 内嵌 forge_tool 协议层拷贝与 canonical 仓库需
    同步演进,版本不对齐会以 ImportError/行为差异显现,commit 需记录 canonical rev。
-6. **正式 digest 回填**:锁内 sha256 以正式 Release digest 为准;本地 E2E digest
-   只服务于本地闭环,正式发布前必须回填并复核 artifact_id 未覆盖。
+6. **stop 落点依赖控制消息到达时刻**:stop 在当前 episode 期间到达则当前集跑完后停;
+   到达时刻的早晚只影响 partial 的集数,不违反「边界停」契约。

--- a/tests/test_skill_local_install.py
+++ b/tests/test_skill_local_install.py
@@ -211,6 +211,37 @@ def test_local_bundle_install_resolves_nodes_from_registry(tmp_path: Path, monke
         _stop_server(server)
 
 
+def test_environment_digest_includes_profile_files(tmp_path: Path, monkeypatch) -> None:
+    """同版本 profile 文件变化必须触发环境重渲染（渲染副本不得滞留旧内容）。"""
+    skill_archive = tmp_path / "skill.tar.gz"
+    node_archive = tmp_path / "gateway.tar.gz"
+    node_sha256 = _node_archive(node_archive)
+    _skill_bundle(skill_archive, node_sha256)
+    skills, runtime = _isolate(tmp_path, monkeypatch)
+    requests, server = _node_registry(monkeypatch, node_archive)
+    try:
+        _install_skill_from_local_bundle(skill_archive)
+        manifest = SkillCatalog(skills).get("demo")
+        builder = SkillEnvironmentBuilder(runtime)
+
+        first_bin = builder.prepare(manifest, "local")
+        first_rendered = first_bin.parent / "launch" / "profiles/local/dataflow.yaml"
+        assert first_rendered.read_text() == "nodes: []\n"
+
+        # 模拟同版本重装：bundle 内 dataflow 内容变化
+        (manifest.bundle_root / "profiles/local/dataflow.yaml").write_text(
+            "nodes: []\npath: ${PAOS_SKILL_NAME}-${PAOS_SKILL_VERSION}\n",
+            encoding="utf-8",
+        )
+
+        second_bin = builder.prepare(manifest, "local")
+        second_rendered = second_bin.parent / "launch" / "profiles/local/dataflow.yaml"
+        assert second_bin.parent != first_bin.parent  # digest 变化 → 新环境目录
+        assert "path: demo-1.0.0" in second_rendered.read_text()
+    finally:
+        _stop_server(server)
+
+
 def test_local_bundle_install_is_idempotent(tmp_path: Path, monkeypatch) -> None:
     skill_archive = tmp_path / "skill.tar.gz"
     node_archive = tmp_path / "gateway.tar.gz"

--- a/tests/test_skill_runtime_manager.py
+++ b/tests/test_skill_runtime_manager.py
@@ -153,6 +153,8 @@ def test_start_uses_named_attached_launcher_for_relative_mujoco_dataflow(
     assert env["FORGE_RUNTIME_BIN"] == str(manager.runtime_root)
     assert (manager.runtime_root / "gateway").is_file()
     assert env["PAOS_SKILL_ROOT"] == str(manager.catalog.root / "move-arm-by-ee")
+    assert env["PAOS_SKILL_NAME"] == "move-arm-by-ee"
+    assert env["PAOS_SKILL_VERSION"] == "1.0.0"
     rendered = (cwd / "dataflow.yaml").read_text()
     assert "${FORGE_RUNTIME_BIN}" not in rendered
     assert f"path: {manager.runtime_root}/gateway" in rendered
@@ -268,3 +270,91 @@ def test_start_rejects_node_that_does_not_match_lock(tmp_path: Path) -> None:
 
     with pytest.raises(RuntimeManagerError, match="receipt does not match Skill lock"):
         manager.start("move-arm-by-ee", "mujoco")
+
+
+def test_start_runs_bundle_start_sh_hook_before_dora(tmp_path: Path, monkeypatch) -> None:
+    manager = _manager(tmp_path)
+    marker = tmp_path / "hook-ran.txt"
+    hook = manager.catalog.root / "move-arm-by-ee" / "start.sh"
+    hook.write_text(
+        f"#!/bin/sh\necho \"$1 $2\" > {marker}\nexit 0\n", encoding="utf-8"
+    )
+    hook.chmod(0o755)
+    commands: list[tuple[list[str], Path | None]] = []
+    launched: list[tuple[list[str], Path | None, dict[str, str] | None]] = []
+
+    def fake_run(command, *, cwd=None, env=None, timeout):
+        commands.append((command, cwd))
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    snapshots = iter([None, {"ok": True}])
+
+    class FakeProcess:
+        def poll(self):
+            return None
+
+    real_popen = subprocess.Popen
+
+    def fake_popen(command, *, cwd=None, env=None, **kwargs):
+        if Path(command[0]).name == "bash":  # start.sh hook 真实执行
+            return real_popen(command, cwd=cwd, env=env, **kwargs)
+        launched.append((command, cwd, env))
+        return FakeProcess()
+
+    monkeypatch.setattr("shutil.which", lambda name: "dora")
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(manager, "_run", fake_run)
+    monkeypatch.setattr(manager, "_gateway_snapshot", lambda manifest: next(snapshots))
+    monkeypatch.setattr(manager, "_flow_running", lambda flow_name: True)
+    monkeypatch.setattr(
+        manager,
+        "_tool_context_readiness",
+        lambda manifest: {tool_id: True for tool_id in manifest.required_tools},
+    )
+
+    state = manager.start("move-arm-by-ee", "mujoco")
+
+    assert state.status == "running"
+    assert marker.read_text().strip() == "move-arm-by-ee 1.0.0"
+    start_command, cwd, env = launched[0]
+    assert start_command[1] == "start"
+    assert env is not None
+    assert env["PAOS_SKILL_NAME"] == "move-arm-by-ee"
+    assert env["PAOS_SKILL_VERSION"] == "1.0.0"
+    # hook 必须先于 dora start 执行：marker 在 start 时已存在
+    assert marker.is_file()
+
+
+def test_start_aborts_when_start_sh_hook_fails(tmp_path: Path, monkeypatch) -> None:
+    manager = _manager(tmp_path)
+    hook = manager.catalog.root / "move-arm-by-ee" / "start.sh"
+    hook.write_text("#!/bin/sh\necho 'download declined'\nexit 3\n", encoding="utf-8")
+    hook.chmod(0o755)
+    launched: list[tuple[list[str], Path | None, dict[str, str] | None]] = []
+
+    class FakeProcess:
+        def poll(self):
+            return None
+
+    real_popen = subprocess.Popen
+
+    def fake_popen(command, *, cwd=None, env=None, **kwargs):
+        if Path(command[0]).name == "bash":  # start.sh hook 真实执行
+            return real_popen(command, cwd=cwd, env=env, **kwargs)
+        launched.append((command, cwd, env))
+        return FakeProcess()
+
+    monkeypatch.setattr("shutil.which", lambda name: "dora")
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(
+        manager,
+        "_run",
+        lambda command, **kwargs: subprocess.CompletedProcess(command, 0, "", ""),
+    )
+    monkeypatch.setattr(manager, "_gateway_snapshot", lambda manifest: None)
+
+    with pytest.raises(RuntimeManagerError, match="start aborted"):
+        manager.start("move-arm-by-ee", "mujoco")
+
+    assert launched == []  # dora up / dora start 均未触发
+    assert manager.state_store.load("move-arm-by-ee") is None  # 未落 starting 状态


### PR DESCRIPTION
  Summary

  Introduces the Forge skill runtime end-to-end: skills are now packaged bundles installed from the resource registry, exposed to agents through the gateway Tool API with full session semantics, and demonstrated by the kai0-libero benchmark skill
  (3-node paos-gateway–policy_runner–benchmark structure). 23 commits, 206 files changed (+637k/−10k, dominated by bundled simulation assets and uv.lock).

  Key changes

  Skill runtime (PhyAgentOS/skill_runtime/)
  - Registry-driven install: paos skill search/install/update/remove/list/inspect against the resource registry (sha256 + size verified, resumable download cache, install confirmation), local-bundle install for development, bundle packaging script
  - Environment builder: node artifacts locked by artifact_id + entrypoint + sha256 (executable_tar_gz), environment digest now also covers profile files so same-version reinstalls re-render dataflow copies
  - Runtime manager: paos skill start runs the bundle's built-in start.sh pre-hook (stdio passthrough; non-zero aborts startup before any state is recorded) and injects PAOS_SKILL_NAME / PAOS_SKILL_VERSION into both the dora daemon env and the
  rendered dataflow env — the only two reliable channels for node config derivation

  Forge integration
  - Replaces the old Forge orchestration/verification framework with the Skill-runtime Tool API; gateway, benchmark, and policy nodes are session-tool-aware (semantics query|action|session, stop bookkeeping, deadline exemption)
  - kai0-libero skill: 3-node single-flow structure; benchmark.controller = describe (query) + run (session, one session = one batch, stop lands at the episode boundary with partial results, seven-field result contract); kai0_libero.policy = serve
  session (attach-or-launch + three-stage readiness gate, stop releases the GPU)

  Docs & tests
  - docs/forge/benchmark-skill-architecture.md rewritten as the implemented-architecture contract (mermaid diagram, tool contracts, seven-field result schema, verification matrix)
  - New test suites: skill local/registry install, package script, runtime CLI, runtime manager, manifest (+31/+90 new cases this round); all green

  Verification

  - L0 unit/contract tests across the three node repos and PhyAgentOS — all green
  - L1–L7 E2E on the deployed chain: gateway session API (register→invoke→202→accepted→stop→stopped→result), policy readiness gate, describe whitelist, 1/2/3-episode batches (≈60 ms/step), stop full-chain (partial 4/5 and 2/3 results, stopped after
  N/M episodes summaries), policy session stop (GPU released), paos skill stop graceful teardown
  - L8 publish: gateway 1.1.0 / libero_benchmark 1.0.0 / kai0_policy 1.0.2 binaries published; nodes.yaml and skills.yaml registered and live on the dev registry (bucket phyagentos-resource-inner, relative object_keys)

  Notes

  - The skill bundle tree still contains README sections describing the earlier Action-tool design; left untouched per convention and flagged as a known inconsistency in the architecture doc (§11) — follow-up cleanup in a separate PR if desired
  - Weights (~12.4 GB) are intentionally not shipped in the bundle; start.sh downloads them at paos skill start with interactive confirmation and sha256 verification
  - Progress monitoring for the PAOS platform itself (CLI/UI consuming per-episode progress events) is out of scope here; the gateway already exposes GET /invocations/{id}/events (SSE with Last-Event-ID replay) for agents

