### PR TITLE
fix(docs): point quickstart clone URL, badges, and manuals at PhyAgentOS-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
   <h3>Recursive Self-Improvement Infrastructure for Physical Agents</h3>
 
   <p>
-    <a href="https://github.com/PhyAgentOS/PhyAgentOS/stargazers">
-      <img src="https://img.shields.io/github/stars/PhyAgentOS/PhyAgentOS?style=social" alt="Stars">
+    <a href="https://github.com/PhyAgentOS/PhyAgentOS-core/stargazers">
+      <img src="https://img.shields.io/github/stars/PhyAgentOS/PhyAgentOS-core?style=social" alt="Stars">
     </a>
-    <a href="https://github.com/PhyAgentOS/PhyAgentOS/network/members">
-      <img src="https://img.shields.io/github/forks/PhyAgentOS/PhyAgentOS?style=social" alt="Forks">
+    <a href="https://github.com/PhyAgentOS/PhyAgentOS-core/network/members">
+      <img src="https://img.shields.io/github/forks/PhyAgentOS/PhyAgentOS-core?style=social" alt="Forks">
     </a>
   </p>
   <p>
@@ -21,7 +21,7 @@
     <a href="https://phy-agent-os.net/">
       <img src="https://img.shields.io/badge/Website-online-FF6B35" alt="Website">
     </a>
-    <a href="https://github.com/PhyAgentOS/PhyAgentOS">
+    <a href="https://github.com/PhyAgentOS/PhyAgentOS-core">
       <img src="https://img.shields.io/badge/PRs-Welcome-2EA44F" alt="PRs">
     </a>
   <p>
@@ -130,8 +130,8 @@ The system keeps three records separate:
 ### 1. Install
 
 ```bash
-git clone https://github.com/PhyAgentOS/PhyAgentOS.git
-cd PhyAgentOS
+git clone https://github.com/PhyAgentOS/PhyAgentOS-core.git
+cd PhyAgentOS-core
 python -m pip install -e .
 
 # Development and tests

--- a/README_zh.md
+++ b/README_zh.md
@@ -4,11 +4,11 @@
   <h3>面向物理智能体的递归自我进化基础设施</h3>
 
   <p>
-    <a href="https://github.com/PhyAgentOS/PhyAgentOS/stargazers">
-      <img src="https://img.shields.io/github/stars/PhyAgentOS/PhyAgentOS?style=social" alt="Stars">
+    <a href="https://github.com/PhyAgentOS/PhyAgentOS-core/stargazers">
+      <img src="https://img.shields.io/github/stars/PhyAgentOS/PhyAgentOS-core?style=social" alt="Stars">
     </a>
-    <a href="https://github.com/PhyAgentOS/PhyAgentOS/network/members">
-      <img src="https://img.shields.io/github/forks/PhyAgentOS/PhyAgentOS?style=social" alt="Forks">
+    <a href="https://github.com/PhyAgentOS/PhyAgentOS-core/network/members">
+      <img src="https://img.shields.io/github/forks/PhyAgentOS/PhyAgentOS-core?style=social" alt="Forks">
     </a>
   </p>
   <p>
@@ -21,7 +21,7 @@
     <a href="https://phy-agent-os.net/">
       <img src="https://img.shields.io/badge/Website-online-FF6B35" alt="Website">
     </a>
-    <a href="https://github.com/PhyAgentOS/PhyAgentOS">
+    <a href="https://github.com/PhyAgentOS/PhyAgentOS-core">
       <img src="https://img.shields.io/badge/PRs-Welcome-2EA44F" alt="PRs">
     </a>
   <p>
@@ -130,8 +130,8 @@ PhyAgentOS 是一个面向具身任务的 Agent 框架。Agent 规划高层动�
 ### 1. 安装
 
 ```bash
-git clone https://github.com/PhyAgentOS/PhyAgentOS.git
-cd PhyAgentOS
+git clone https://github.com/PhyAgentOS/PhyAgentOS-core.git
+cd PhyAgentOS-core
 python -m pip install -e .
 
 # 开发与测试依赖

--- a/docs/en/02-user-manual.md
+++ b/docs/en/02-user-manual.md
@@ -10,8 +10,8 @@ PhyAgentOS supports Python 3.11 and 3.12. Forge Gateway, Dora, robot drivers, si
 and locked node artifacts are deployed separately when a robot Skill needs them.
 
 ```bash
-git clone https://github.com/PhyAgentOS/PhyAgentOS.git
-cd PhyAgentOS
+git clone https://github.com/PhyAgentOS/PhyAgentOS-core.git
+cd PhyAgentOS-core
 python -m pip install -e .
 paos onboard
 ```

--- a/docs/zh/02-user-manual.md
+++ b/docs/zh/02-user-manual.md
@@ -10,8 +10,8 @@ PhyAgentOS 支持 Python 3.11 和 3.12。Forge Gateway、Dora、机器人驱动�
 制品在机器人 Skill 需要时独立部署。
 
 ```bash
-git clone https://github.com/PhyAgentOS/PhyAgentOS.git
-cd PhyAgentOS
+git clone https://github.com/PhyAgentOS/PhyAgentOS-core.git
+cd PhyAgentOS-core
 python -m pip install -e .
 paos onboard
 ```


### PR DESCRIPTION
## Problem

The quick start's first command (`git clone https://github.com/PhyAgentOS/PhyAgentOS.git`) and several badge links point at `PhyAgentOS/PhyAgentOS`, a repository that does not exist in this organization (only `PhyAgentOS-core`, `PhyAgentOS-website`, and `PhyAgentOS-legacy` exist). A fresh user following the README hits a 404 on the very first step.

## Fix

Update all stale references to `PhyAgentOS/PhyAgentOS-core`:

- clone URL and `cd` target in `README.md`, `README_zh.md`, `docs/en/02-user-manual.md`, `docs/zh/02-user-manual.md`
- star/fork badge links (<a href> + shields.io img src) in both READMEs
- the PRs-welcome repo link in both READMEs

4 files, 18 line changes.

## Verification

- `grep -rn 'PhyAgentOS/PhyAgentOS[^-]' --exclude-dir=.git .` returns no matches
- Badge targets resolve against PhyAgentOS-core (stargazers / network/members pages)
- The website badge domain `phy-agent-os.net` was checked and is a live redirect alias of `phy-agent-os.x-era.com` (left unchanged)