### PR TITLE
fix(skill-runtime): actionable legacy-state error; hide version flags

### DIFF
--- a/PhyAgentOS/cli/commands.py
+++ b/PhyAgentOS/cli/commands.py
@@ -1148,7 +1148,10 @@ def _resolve_skill_install_source(name: str) -> str | Path:
 @skill_app.command("install")
 def skill_install(
     name: str = typer.Argument(..., help="Registry Skill name or local .tar.gz bundle"),
-    version: str | None = typer.Option(None, "--version", "-v", help="Exact version"),
+    # Hidden until the Registry serves more than one version per Skill.
+    version: str | None = typer.Option(
+        None, "--version", "-v", help="Exact version", hidden=True
+    ),
     index: str | None = typer.Option(
         None,
         "--index",
@@ -1178,7 +1181,10 @@ def skill_install(
 @skill_app.command("update")
 def skill_update(
     name: str = typer.Argument(..., help="Installed Skill name"),
-    version: str | None = typer.Option(None, "--version", "-v", help="Target version"),
+    # Hidden until the Registry serves more than one version per Skill.
+    version: str | None = typer.Option(
+        None, "--version", "-v", help="Target version", hidden=True
+    ),
     index: str | None = typer.Option(
         None,
         "--index",

--- a/PhyAgentOS/skill_runtime/state.py
+++ b/PhyAgentOS/skill_runtime/state.py
@@ -39,6 +39,10 @@ class StateError(ValueError):
     """Raised when persisted runtime state is malformed."""
 
 
+class StateVersionError(StateError):
+    """Raised when persisted runtime state uses an unsupported schema version."""
+
+
 def utc_now() -> str:
     return datetime.now(UTC).isoformat()
 
@@ -69,14 +73,17 @@ class RuntimeState:
     def from_dict(cls, value: Any) -> RuntimeState:
         if not isinstance(value, dict):
             raise StateError("runtime state must be a JSON object")
+        if value.get("state_version") != STATE_VERSION:
+            raise StateVersionError(
+                f"state_version must be {STATE_VERSION}, "
+                f"got {value.get('state_version')!r}"
+            )
         unknown = sorted(set(value) - _FIELDS)
         if unknown:
             raise StateError(f"runtime state has unknown field(s): {', '.join(unknown)}")
         missing = sorted(_FIELDS - set(value))
         if missing:
             raise StateError(f"runtime state is missing field(s): {', '.join(missing)}")
-        if value.get("state_version") != STATE_VERSION:
-            raise StateError(f"state_version must be {STATE_VERSION}")
         required = (
             "skill_name",
             "profile",
@@ -192,7 +199,16 @@ class RuntimeStateStore:
             raise StateError("cannot read runtime state") from exc
         except json.JSONDecodeError as exc:
             raise StateError("runtime state is not valid JSON") from exc
-        state = RuntimeState.from_dict(value)
+        try:
+            state = RuntimeState.from_dict(value)
+        except StateVersionError as exc:
+            raise StateError(
+                f"runtime state file {path} was written by an older "
+                f"PhyAgentOS ({exc}) and cannot be read by this version; "
+                "move it aside and retry — a fresh state file is created "
+                "on the next start:\n"
+                f"  mv {path} {path}.bak"
+            ) from exc
         if state.skill_name != skill_name:
             raise StateError("runtime state Skill name does not match its filename")
         return state


### PR DESCRIPTION
## Problem

Two issues hit users upgrading to v1.0.0:

1. `paos skill start` fails on state files written by pre-1.0 builds (`~/.PhyAgentOS/run/skills/<skill>.json` with `state_version: 1`). In `RuntimeState.from_dict` the missing-field check runs before the version check, so the error blames five missing fields instead of the old schema, and offers no recovery path.
2. `paos skill install --version` / `paos skill update --version` can only fail today: the Registry serves a single version per Skill.

## What

- `state.py`: check `state_version` first; add a `StateVersionError` subclass. `RuntimeStateStore.load` now raises an actionable message naming the offending file and the exact command to move it aside — a fresh v2 state file is created on the next start:
  ```
  runtime state file /home/u/.PhyAgentOS/run/skills/move-arm-by-ee.json was written by an older
  PhyAgentOS (state_version must be 2, got 1) and cannot be read by this version; move it aside
  and retry — a fresh state file is created on the next start:
    mv /home/u/.PhyAgentOS/run/skills/move-arm-by-ee.json /home/u/.PhyAgentOS/run/skills/move-arm-by-ee.json.bak
  ```
- `commands.py`: hide `--version/-v` from `skill install` and `skill update` help (`hidden=True`), keeping the options functional so they can be re-enabled once the Registry serves multiple versions.

## Verification

- An 11-field `state_version: 1` fixture (replicating a real pre-1.0 file) now produces the message above, including path and `mv` command; previously it reported five missing fields.
- v2 state save/load round-trips unchanged.
- `paos skill install --help` and `paos skill update --help` no longer list `--version`.
- `pytest tests/` — 7 passed.