### PR TITLE
feat(game): add independent Stardew and Minecraft agents

### DIFF
--- a/.github/workflows/game-agents.yml
+++ b/.github/workflows/game-agents.yml
@@ -1,0 +1,36 @@
+name: Game Agents
+
+on:
+  push:
+    branches: [main, feature/stardew-minecraft]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    env:
+      LITELLM_LOCAL_MODEL_COST_MAP: "True"
+      CUSTOM_TIKTOKEN_CACHE_DIR: .test-token-cache
+      TIKTOKEN_CACHE_DIR: .test-token-cache
+    steps:
+      - if: runner.os == 'Windows'
+        run: git config --global core.longpaths true
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: python -m pip install -e . "pytest>=9,<10" "pytest-asyncio>=1.3,<2" ruff
+      - run: python -c "import tiktoken; tiktoken.get_encoding('cl100k_base')"
+      - run: python -m ruff check --ignore N999 PhyAgentOS/game_agents PhyAgentOS/cli/general_game_commands.py tests/game_agents
+      - run: python -m pytest tests
+      - run: paos general-game --help
+      - run: paos minecraft warmup --help
+      - run: paos minecraft benchmark --help
+      - run: python -m pip wheel --no-deps --wheel-dir dist .

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ build/
 .venv/
 venv/
 __pycache__/
+node_modules/
 poetry.lock
 .pytest_cache/
 botpy.log

--- a/PhyAgentOS/benchmarks/minecraft/techtree/__init__.py
+++ b/PhyAgentOS/benchmarks/minecraft/techtree/__init__.py
@@ -6,7 +6,11 @@ from PhyAgentOS.benchmarks.minecraft.techtree.evaluator import (
     inventory_count,
     inventory_counts,
 )
-from PhyAgentOS.benchmarks.minecraft.techtree.harness import BenchmarkResult, run_task
+from PhyAgentOS.benchmarks.minecraft.techtree.harness import (
+    BenchmarkResult,
+    run_task,
+    run_task_spec,
+)
 from PhyAgentOS.benchmarks.minecraft.techtree.loader import list_tasks, load_manifest, load_task
 from PhyAgentOS.benchmarks.minecraft.techtree.schema import (
     DEFAULT_ARENA_BOUNDARY_BLOCK,
@@ -41,4 +45,5 @@ __all__ = [
     "load_manifest",
     "load_task",
     "run_task",
+    "run_task_spec",
 ]

--- a/PhyAgentOS/benchmarks/minecraft/techtree/harness.py
+++ b/PhyAgentOS/benchmarks/minecraft/techtree/harness.py
@@ -70,6 +70,23 @@ def run_task(
     """
 
     task = load_task(task_id, manifest_path)
+    return run_task_spec(task, agent_fn, world_adapter)
+
+
+def run_task_spec(
+    task: TechTreeTask,
+    agent_fn: AgentFn,
+    world_adapter: WorldAdapter,
+    *,
+    metadata: Mapping[str, Any] | None = None,
+) -> BenchmarkResult:
+    """Run an already loaded task.
+
+    ``run_task`` remains the stable manifest-backed API.  This companion is
+    used by the fixed warm-up curriculum, whose targets deliberately do not
+    appear in the benchmark manifest.
+    """
+
     started = _utc_now()
     initial_observation: Mapping[str, Any] | None = None
     final_observation: Mapping[str, Any] | None = None
@@ -108,7 +125,12 @@ def run_task(
         final_observation=final_observation,
         agent_result=agent_result,
         error=error,
-        metadata={"benchmark": "minecraft_techtree", "tier": task.tier, "family": task.family},
+        metadata={
+            "benchmark": "minecraft_techtree",
+            "tier": task.tier,
+            "family": task.family,
+            **dict(metadata or {}),
+        },
     )
 
 

--- a/PhyAgentOS/cli/commands.py
+++ b/PhyAgentOS/cli/commands.py
@@ -1000,6 +1000,10 @@ from PhyAgentOS.cli.stardew_commands import stardew_app
 
 app.add_typer(stardew_app, name="stardew")
 
+from PhyAgentOS.cli.general_game_commands import run_general_game
+
+app.command("general-game")(run_general_game)
+
 
 if __name__ == "__main__":
     app()

--- a/PhyAgentOS/cli/general_game_commands.py
+++ b/PhyAgentOS/cli/general_game_commands.py
@@ -1,0 +1,144 @@
+"""Run Planner/Actor sessions through the existing runtime and target contracts."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+from contextlib import asynccontextmanager
+from importlib.resources import files
+from pathlib import Path
+
+import typer
+import yaml
+
+from PhyAgentOS.game_agents.stardew import register_general_game
+from PhyAgentOS.providers.custom_provider import CustomProvider
+from PhyAgentOS.runtime.preflight.runtime_compatibility_preflight import (
+    RuntimeCompatibilityPreflight,
+)
+from PhyAgentOS.runtime.schemas import SessionSpec, SkillRuntimeSpec, TargetSpec
+from PhyAgentOS.runtime.sessions.session_runner import SessionRunner
+from PhyAgentOS.runtime.watchdog.runtime_registry import SkillRuntimeRegistry, TargetRuntimeRegistry
+from PhyAgentOS.runtime.watchdog.scheduler import ScheduledSession
+
+
+def success_check(expected):
+    if not isinstance(expected, dict) or not expected:
+        raise ValueError("success checks must be a nonempty {observation.path: value} object")
+    for path, value in expected.items():
+        if not isinstance(path, str) or not all(path.split(".")):
+            raise ValueError("success checks require nonempty observation paths")
+        if isinstance(value, dict) and "$lt" in value:
+            limit = value["$lt"]
+            if set(value) != {"$lt"} or type(limit) not in (int, float) or not math.isfinite(limit):
+                raise ValueError("$lt requires a single finite numeric upper bound")
+
+    def verify(observation, feedback):
+        for path, expected_value in expected.items():
+            value = observation
+            for key in path.split("."):
+                if not isinstance(value, dict) or key not in value:
+                    return False
+                value = value[key]
+            if isinstance(expected_value, dict) and "$lt" in expected_value:
+                if (
+                    type(value) not in (int, float)
+                    or not math.isfinite(value)
+                    or not value < expected_value["$lt"]
+                ):
+                    return False
+            elif value != expected_value:
+                return False
+        return True
+
+    return verify
+
+
+def run_general_game(
+    workspace: Path = typer.Option(..., help="Session workspace directory"),
+    target: Path = typer.Option(..., help="TargetSpec YAML"),
+    session: Path = typer.Option(..., help="SessionSpec YAML"),
+    actions: Path = typer.Option(..., help="Action catalog JSON"),
+    model: str = typer.Option(..., help="Model name"),
+    api_base: str = typer.Option("http://localhost:8000/v1", help="OpenAI-compatible API base"),
+    evolve: bool = typer.Option(False, help="Record unverified memory candidates after execution"),
+    success_checks: Path | None = typer.Option(None, help="Observed completion conditions JSON"),
+) -> None:
+    """Execute a configured game task with bounded Planner/Actor rounds."""
+    # Core resolves relative contract paths through this directory, even on first run.
+    workspace.mkdir(parents=True, exist_ok=True)
+    target = TargetSpec.model_validate(yaml.safe_load(target.read_text(encoding="utf-8")))
+    session = SessionSpec.model_validate(yaml.safe_load(session.read_text(encoding="utf-8")))
+    skill = SkillRuntimeSpec.model_validate(
+        yaml.safe_load(
+            files("PhyAgentOS")
+            .joinpath("templates/configs/skillruntimes/general_game.yaml")
+            .read_text(encoding="utf-8"),
+        )
+    )
+    if session.skillruntime_ref.removeprefix("skillruntime://") != skill.id:
+        raise typer.BadParameter("session.skillruntime_ref must reference general_game")
+    if session.target_ref.removeprefix("target://") != target.id:
+        raise typer.BadParameter("session.target_ref must match the supplied target")
+    verify = (
+        success_check(json.loads(success_checks.read_text(encoding="utf-8")))
+        if success_checks
+        else None
+    )
+    if (
+        target.runtime.target_runtime
+        in {
+            "StardewValleyTargetRuntime",
+            "MinecraftTargetRuntime",
+        }
+        and verify is None
+    ):
+        raise typer.BadParameter(
+            "native game targets require --success-checks to verify task completion"
+        )
+
+    @asynccontextmanager
+    async def provider_factory():
+        provider = CustomProvider(
+            api_key=os.environ.get("GAME_AGENT_API_KEY", "no-key"),
+            api_base=api_base,
+            default_model=model,
+        )
+        # CustomProvider owns this client; Core has no provider-wide close API.
+        async with provider._client:
+            yield provider
+
+    register_general_game(
+        provider_factory,
+        model=model,
+        action_catalog=json.loads(actions.read_text(encoding="utf-8")),
+        memory_workspace=workspace,
+        evolve=evolve,
+        verify=verify,
+    )
+    scheduled = ScheduledSession(session, target, skill, target.id, skill.id)
+    preflight = RuntimeCompatibilityPreflight(workspace).check(scheduled)
+    if preflight.verdict != "accepted":
+        raise typer.BadParameter(preflight.model_dump_json(indent=2))
+    runner = SessionRunner(
+        session=session,
+        target_spec=target,
+        skillruntime_spec=skill,
+        adapter_plan=preflight.adapter_plan,
+        target=TargetRuntimeRegistry().build(
+            target,
+            target_endpoint=session.routing.target_endpoint or target.runtime.target_endpoint,
+        ),
+        skill_runtime=SkillRuntimeRegistry().build(skill.runtime),
+        policy_client=None,
+        perception_runtime=None,
+        perception_plan=None,
+    )
+    try:
+        result = runner.start()
+        print(result.model_dump_json(indent=2))
+        if not result.success:
+            raise typer.Exit(1)
+    finally:
+        runner.close()

--- a/PhyAgentOS/cli/minecraft_commands.py
+++ b/PhyAgentOS/cli/minecraft_commands.py
@@ -47,6 +47,7 @@ _MC_SYSTEM_PROMPT = (
     "place: {x,y,z,face} 面编号0=下1=上2=北3=南4=西5=东\n"
     "collect: {block_type,count} 自动寻找并采集\n"
     "craft: {recipe_id,count} 合成（需附近有工作台）\n"
+    "smelt: {input,fuel,count} 使用附近熔炉烧炼\n"
     "select_slot: {slot:0-8} 切换快捷键\n"
     "equip: {item,destination:\"hand\"|\"torso\"|...} 装备指定物品（如 {\"item\":\"wooden_shovel\"}）\n"
     "drop: {slot} 丢弃物品\n"
@@ -434,3 +435,75 @@ def minecraft_tp(
     target.step({"type": "move", "params": {"dx": x, "dy": y, "dz": z, "absolute": True}})
     console.print(f"[green]✓[/green] bot 已传送到 ({x}, {y}, {z})")
     target.close()
+
+
+@minecraft_app.command("warmup")
+def minecraft_warmup(
+    output_dir: str = typer.Option(..., "--output-dir", "-o", help="Skill Graph 输出根目录"),
+    bridge_url: str = typer.Option("http://127.0.0.1:3001", "--url", "-u"),
+):
+    """固定运行 W01-W07，每个任务一个 trial，并保存冻结图谱和 benchmark 可写副本。"""
+    from PhyAgentOS.game_agents.minecraft import run_warmup
+    from PhyAgentOS.runtime.benchmark.minecraft_glue import MinecraftTargetWorldAdapter
+    from PhyAgentOS.runtime.targets.game.minecraft_target import MinecraftTarget
+
+    target = MinecraftTarget({"bridge_url": bridge_url, "verify_ssl": False})
+    try:
+        target.build()
+        result = run_warmup(MinecraftTargetWorldAdapter(target), output_dir)
+    except Exception as exc:
+        console.print(f"[red]预热失败: {exc}[/red]")
+        raise typer.Exit(1) from exc
+    finally:
+        target.close()
+    console.print_json(data=result)
+
+
+@minecraft_app.command("benchmark")
+def minecraft_benchmark(
+    output_dir: str = typer.Option(..., "--output-dir", "-o", help="episode 结果目录"),
+    graph_dir: str = typer.Option(..., "--graph-dir", help="预热产生的 benchmark_graph 目录"),
+    tasks: str = typer.Option("wooden.obtain_oak_log", "--tasks", help="逗号分隔 task id"),
+    all_tasks: bool = typer.Option(False, "--all", help="运行 manifest 中全部任务"),
+    trials: int = typer.Option(1, "--trials", min=1),
+    run_id: str | None = typer.Option(None, "--run-id", help="可复现的批次 ID；默认自动生成"),
+    bridge_url: str = typer.Option("http://127.0.0.1:3001", "--url", "-u"),
+):
+    """串行执行 benchmark，并在每个 episode 后同步沉淀 Skill Graph。"""
+    from PhyAgentOS.game_agents.minecraft import (
+        build_scripted_agent,
+        run_benchmark_tasks,
+    )
+    from PhyAgentOS.benchmarks.minecraft.techtree import list_tasks
+    from PhyAgentOS.runtime.benchmark.minecraft_glue import MinecraftTargetWorldAdapter
+    from PhyAgentOS.runtime.targets.game.minecraft_target import MinecraftTarget
+
+    task_ids = (
+        [task.id for task in list_tasks()]
+        if all_tasks
+        else [task.strip() for task in tasks.split(",") if task.strip()]
+    )
+    if not task_ids:
+        raise typer.BadParameter("--tasks must contain at least one task id")
+    target = MinecraftTarget({"bridge_url": bridge_url, "verify_ssl": False})
+    try:
+        target.build()
+        results = run_benchmark_tasks(
+            task_ids,
+            build_scripted_agent,
+            MinecraftTargetWorldAdapter(target),
+            graph_dir=graph_dir,
+            results_dir=output_dir,
+            trials=trials,
+            run_id=run_id,
+        )
+    except Exception as exc:
+        console.print(f"[red]benchmark 失败: {exc}[/red]")
+        raise typer.Exit(1) from exc
+    finally:
+        target.close()
+    passed = sum(result.success for result in results)
+    actual_run_id = results[0].metadata.get("run_id") if results else run_id
+    console.print(
+        f"[green]完成[/green]: {passed}/{len(results)} episodes passed (run_id={actual_run_id})"
+    )

--- a/PhyAgentOS/game_agents/README.md
+++ b/PhyAgentOS/game_agents/README.md
@@ -1,0 +1,23 @@
+# Game Agents
+
+Independent game-agent workflows within the Core package.
+
+```text
+game_agents/
+├── stardew/     # Planner–Actor runtime, decisions, receipts and role memory
+└── minecraft/   # Skill Graph, evidence store, warm-up and benchmark runner
+```
+
+| Module | Command | Documentation |
+|:-------|:--------|:--------------|
+| Stardew | `paos general-game` | [Module](stardew/README.md), [English](../../docs/en/general-game.md), [中文](../../docs/zh/general-game.md) |
+| Minecraft | `paos minecraft warmup` / `benchmark` | [Module](minecraft/README.md), [Guide](../../docs/scenarios/game/minecraft/4_benchmark.md) |
+
+The modules do not import each other. Stardew keeps its existing `GeneralGameSkillRuntime`
+and registration API; Minecraft keeps its `AgentFn`, `WorldAdapter` and graph APIs.
+Game-specific target clients and bridges remain in their existing Core locations.
+
+Model-generated Stardew memory candidates remain unverified. Minecraft graph claims follow
+its documented single-observation verification policy. These policies are independent.
+
+Run `python -m pytest tests/game_agents` to exercise both modules without a live game server.

--- a/PhyAgentOS/game_agents/__init__.py
+++ b/PhyAgentOS/game_agents/__init__.py
@@ -1,0 +1,1 @@
+"""Independent game-agent workflows hosted by PhyAgentOS Core."""

--- a/PhyAgentOS/game_agents/minecraft/README.md
+++ b/PhyAgentOS/game_agents/minecraft/README.md
@@ -1,0 +1,41 @@
+# Minecraft Skill Graph v1
+
+This package ports the evidence-backed Skill Graph v1 protocol to the
+Mineflayer tech-tree benchmark. It intentionally excludes MineStudio,
+STEVE-1 log import, curriculum generation, and automatic task exploration.
+
+## Protocol
+
+- Warm-up always runs W01-W07 once in manifest order, with an isolated reset
+  for every case.
+- The backend does not expose seed control. Every artifact records
+  `backend_seed_control=false`; claim verification never depends on seed
+  replay.
+- One non-confounded observation promotes its success or failure claim to
+  `verified`; no seed replay or second validation task is scheduled.
+- `warmup_frozen/` is content-hashed and read-only. `benchmark_graph/` is a
+  derived writable copy.
+- A benchmark episode is committed to SQLite and its JSON artifact is synced
+  before the next episode starts. No exploration task is generated.
+
+## CLI
+
+```bash
+paos minecraft warmup \
+  --url http://127.0.0.1:3001 \
+  --output-dir outputs/minecraft-skill-graph
+
+paos minecraft benchmark \
+  --url http://127.0.0.1:3001 \
+  --graph-dir outputs/minecraft-skill-graph/benchmark_graph \
+  --output-dir outputs/minecraft-benchmark \
+  --tasks wooden.obtain_oak_log \
+  --trials 1 \
+  --run-id smoke-001
+```
+
+Use `--all` instead of `--tasks` to run the full 40-task manifest. The bundled
+executor is a deterministic Mineflayer baseline; callers may inject any
+`AgentFn` through the Python API. If `--run-id` is omitted, a unique ID is
+generated; results are stored below `<output-dir>/<run-id>/` so repeated runs
+never reuse logical trial IDs or overwrite earlier evidence.

--- a/PhyAgentOS/game_agents/minecraft/__init__.py
+++ b/PhyAgentOS/game_agents/minecraft/__init__.py
@@ -1,0 +1,26 @@
+"""Evidence-backed Skill Graph v1 for the Minecraft benchmark."""
+
+from .model import Claim, Evidence, Node, RuntimeFingerprint, canonical_hash
+from .runner import (
+    WARMUP_MANIFEST_PATH,
+    build_scripted_agent,
+    run_benchmark_tasks,
+    run_warmup,
+)
+from .store import GraphStore, clone_frozen_graph, freeze_graph, load_frozen_graph
+
+__all__ = [
+    "Claim",
+    "Evidence",
+    "GraphStore",
+    "Node",
+    "RuntimeFingerprint",
+    "WARMUP_MANIFEST_PATH",
+    "build_scripted_agent",
+    "canonical_hash",
+    "clone_frozen_graph",
+    "freeze_graph",
+    "load_frozen_graph",
+    "run_benchmark_tasks",
+    "run_warmup",
+]

--- a/PhyAgentOS/game_agents/minecraft/model.py
+++ b/PhyAgentOS/game_agents/minecraft/model.py
@@ -1,0 +1,126 @@
+"""Small, stable data model for Skill Graph v1."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+NODE_TYPES = {"Entity", "StateCondition", "SkillAction", "Goal", "FailurePattern", "Remedy"}
+EDGE_TYPES = {
+    "TRANSITION",
+    "HARNESS_REJECTION",
+    "REQUIRES",
+    "REMEDY_FOR",
+    "COMPOSES",
+    "PREFER_OVER",
+    "REFINES",
+    "CONTRADICTS",
+}
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+        default=str,
+    )
+
+
+def canonical_hash(value: Any, prefix: str = "sha256") -> str:
+    digest = hashlib.sha256(canonical_json(value).encode()).hexdigest()
+    return f"{prefix}:{digest}"
+
+
+@dataclass(frozen=True)
+class RuntimeFingerprint:
+    profile: Mapping[str, Any]
+
+    @property
+    def hash(self) -> str:
+        return canonical_hash(dict(self.profile), "runtime")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"hash": self.hash, "profile": dict(self.profile)}
+
+
+@dataclass(frozen=True)
+class Node:
+    node_type: str
+    key: str
+    attributes: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def id(self) -> str:
+        if self.node_type not in NODE_TYPES:
+            raise ValueError(f"invalid node type: {self.node_type}")
+        return canonical_hash(
+            {"node_type": self.node_type, "key": self.key, "attributes": dict(self.attributes)},
+            "node",
+        )
+
+
+@dataclass(frozen=True)
+class Evidence:
+    episode_id: str
+    trial_id: str
+    task_id: str
+    source: str
+    outcome: str
+    payload: Mapping[str, Any]
+    runtime_fingerprint: str
+    confounded: bool = False
+
+    @property
+    def id(self) -> str:
+        return canonical_hash(
+            {
+                "episode_id": self.episode_id,
+                "trial_id": self.trial_id,
+                "task_id": self.task_id,
+                "source": self.source,
+                "outcome": self.outcome,
+                "payload": dict(self.payload),
+                "runtime_fingerprint": self.runtime_fingerprint,
+                "confounded": self.confounded,
+            },
+            "evidence",
+        )
+
+
+@dataclass(frozen=True)
+class Claim:
+    edge_type: str
+    subject: Node
+    object: Node
+    action: Mapping[str, Any]
+    preconditions: Mapping[str, Any]
+    effects: Mapping[str, Any]
+    scope: Mapping[str, Any]
+    outcome: str
+    evidence_class: str = "benchmark_episode"
+    serveable: bool = True
+
+    @property
+    def id(self) -> str:
+        if self.edge_type not in EDGE_TYPES:
+            raise ValueError(f"invalid edge type: {self.edge_type}")
+        return canonical_hash(
+            {
+                "edge_type": self.edge_type,
+                "subject": self.subject.id,
+                "object": self.object.id,
+                "action": dict(self.action),
+                "preconditions": dict(self.preconditions),
+                "effects": dict(self.effects),
+                "scope": dict(self.scope),
+                "outcome": self.outcome,
+                "evidence_class": self.evidence_class,
+                "serveable": self.serveable,
+            },
+            "claim",
+        )

--- a/PhyAgentOS/game_agents/minecraft/runner.py
+++ b/PhyAgentOS/game_agents/minecraft/runner.py
@@ -1,0 +1,335 @@
+"""Fixed warm-up and synchronous benchmark experience accumulation."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import uuid
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping
+
+from PhyAgentOS.benchmarks.minecraft.techtree.harness import (
+    AgentFn,
+    BenchmarkResult,
+    WorldAdapter,
+    run_task_spec,
+)
+from PhyAgentOS.benchmarks.minecraft.techtree.loader import (
+    DEFAULT_MANIFEST_PATH,
+    list_tasks,
+    load_task,
+)
+from PhyAgentOS.benchmarks.minecraft.techtree.schema import TaskManifest, TechTreeTask
+
+from .model import RuntimeFingerprint, canonical_hash
+from .store import GraphStore, clone_frozen_graph, freeze_graph, sync_mutable_graph
+
+WARMUP_MANIFEST_PATH = Path(__file__).with_name("warmup_manifest.json")
+AgentFactory = Callable[[TechTreeTask, WorldAdapter], Any]
+
+
+def _json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _atomic_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, indent=2, ensure_ascii=False, sort_keys=True, default=str)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def default_runtime_fingerprint() -> RuntimeFingerprint:
+    manifest_hash = canonical_hash(_json(DEFAULT_MANIFEST_PATH), "manifest")
+    return RuntimeFingerprint(
+        {
+            "skill_graph_protocol": 1,
+            "minecraft_version": "1.20.4",
+            "backend": "mineflayer_http",
+            "backend_seed_control": False,
+            "claim_verification_policy": "single_observation",
+            "benchmark_manifest_hash": manifest_hash,
+        }
+    )
+
+
+def load_warmup_tasks(
+    path: str | Path = WARMUP_MANIFEST_PATH,
+) -> tuple[list[TechTreeTask], list[str]]:
+    data = _json(Path(path))
+    order = list(data.get("case_order") or [])
+    trials = list(data.get("trials") or [])
+    tasks = list(
+        TaskManifest.from_dict(
+            {
+                "version": "skill_graph_warmup_v1",
+                "name": "skill_graph_warmup",
+                "tasks": data.get("tasks", []),
+            }
+        ).tasks
+    )
+    if [task.id for task in tasks] != order or order != [f"W{i:02d}" for i in range(1, 8)]:
+        raise ValueError("warm-up must contain W01-W07 in fixed order")
+    if trials != ["trial-01"]:
+        raise ValueError("warm-up must use exactly one logical trial per case")
+    benchmark_targets = {task.target_item for task in list_tasks()}
+    overlap = sorted(benchmark_targets & {task.target_item for task in tasks})
+    if overlap:
+        raise ValueError(f"warm-up final targets overlap benchmark targets: {overlap}")
+    return tasks, trials
+
+
+def _table_or_furnace_setup(task: TechTreeTask, block: str) -> list[dict[str, Any]]:
+    x, y, z = task.setup.arena.origin
+    return [
+        {"type": "equip", "params": {"item": block}},
+        {"type": "place", "params": {"x": x + 2, "y": y - 1, "z": z, "face": 1}},
+    ]
+
+
+def scripted_actions(task: TechTreeTask) -> list[dict[str, Any]]:
+    """A deterministic Mineflayer baseline; it does not explore or call an LLM."""
+
+    setup_items = [item.item for item in task.setup.inventory]
+    if task.family == "dig_pickup":
+        tools = [item for item in setup_items if item.endswith(("_axe", "_pickaxe", "_shovel"))]
+        actions = [{"type": "equip", "params": {"item": tools[0]}}] if tools else []
+        block = task.setup.blocks[0].block
+        return actions + [
+            {"type": "collect", "params": {"block_type": block, "count": 1, "max_distance": 8}}
+        ]
+    if task.family == "smelting":
+        inputs = {"iron_ingot": "raw_iron", "gold_ingot": "raw_gold", "baked_potato": "potato"}
+        actions = _table_or_furnace_setup(task, "furnace")
+        return actions + [
+            {
+                "type": "smelt",
+                "params": {
+                    "input": inputs[task.target_item],
+                    "fuel": "coal",
+                    "count": task.success_criterion.count,
+                },
+            }
+        ]
+    actions = (
+        _table_or_furnace_setup(task, "crafting_table") if task.family == "crafting_table" else []
+    )
+    return actions + [
+        {
+            "type": "craft",
+            "params": {"recipe_id": task.target_item, "count": task.success_criterion.count},
+        }
+    ]
+
+
+def build_scripted_agent(task: TechTreeTask, world: WorldAdapter) -> dict[str, Any]:
+    actions = scripted_actions(task)
+    execute = getattr(world, "execute_action", None)
+    if not callable(execute):
+        raise TypeError("scripted benchmark requires a world adapter with execute_action")
+    results = []
+    for action in actions:
+        response = execute(action["type"], action.get("params", {}))
+        results.append({"action": action, "response": response})
+        if isinstance(response, Mapping) and response.get("ok") is False:
+            break
+    return {"executor": "scripted_baseline", "actions": actions, "results": results}
+
+
+def _result_record(result: BenchmarkResult, *, trial_id: str) -> dict[str, Any]:
+    value = result.to_dict()
+    value["trial_id"] = trial_id
+    value["backend_seed_control"] = False
+    return value
+
+
+def _benchmark_run_id() -> str:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return f"run-{timestamp}-{uuid.uuid4().hex[:8]}"
+
+
+def _graph_agent(agent_fn: AgentFn, store: GraphStore) -> AgentFn:
+    def run(task: TechTreeTask, world: WorldAdapter) -> Any:
+        context, claim_ids = store.retrieve(task.title, world.observe())
+        enriched = replace(
+            task,
+            raw={
+                **task.raw,
+                "skill_graph_context": context,
+                "skill_graph_claim_ids": claim_ids,
+            },
+        )
+        result = agent_fn(enriched, world)
+        graph = {"context": context, "claim_ids": claim_ids}
+        if isinstance(result, Mapping):
+            return {**dict(result), "skill_graph": graph}
+        return {"result": result, "skill_graph": graph}
+
+    return run
+
+
+def run_warmup(
+    world_adapter: WorldAdapter,
+    output_dir: str | Path,
+    *,
+    agent_fn: AgentFn = build_scripted_agent,
+    runtime: RuntimeFingerprint | None = None,
+    manifest_path: str | Path = WARMUP_MANIFEST_PATH,
+) -> dict[str, Any]:
+    """Run W01-W07 once, freeze the result, and derive a writable copy."""
+
+    runtime = runtime or default_runtime_fingerprint()
+    output = Path(output_dir).resolve()
+    frozen = output / "warmup_frozen"
+    mutable = output / "benchmark_graph"
+    recovery = output / "warmup_working"
+    if frozen.exists() or mutable.exists() or recovery.exists():
+        raise FileExistsError("skill graph output already exists; choose an empty output directory")
+    output.mkdir(parents=True, exist_ok=True)
+    working = output / f".warmup-{os.getpid()}"
+    working.mkdir()
+    store = GraphStore(working / "graph.sqlite")
+    store.set_metadata("runtime", runtime.to_dict())
+    records: list[dict[str, Any]] = []
+    try:
+        tasks, trials = load_warmup_tasks(manifest_path)
+        for task in tasks:
+            for trial_id in trials:
+                logical_trial = f"{task.id}:{trial_id}"
+                result = run_task_spec(
+                    task,
+                    _graph_agent(agent_fn, store),
+                    world_adapter,
+                    metadata={"phase": "warmup"},
+                )
+                store.record_episode(
+                    task,
+                    result,
+                    trial_id=logical_trial,
+                    source="warmup",
+                    runtime=runtime,
+                )
+                records.append(_result_record(result, trial_id=logical_trial))
+                if result.error:
+                    raise RuntimeError(f"warm-up {task.id}/{trial_id} errored: {result.error}")
+        _atomic_json(working / "warmup_results.json", records)
+        manifest = freeze_graph(
+            store,
+            working,
+            runtime,
+            extra={
+                "origin": "fixed_warmup",
+                "course": "W01-W07",
+                "trials_per_case": 1,
+                "claim_verification_policy": "single_observation",
+                "complete": True,
+            },
+        )
+        os.replace(working, frozen)
+        mutable_store = clone_frozen_graph(frozen, mutable)
+        sync_mutable_graph(
+            mutable_store,
+            mutable,
+            runtime,
+            extra={"origin": "benchmark_online", "base_frozen_graph_hash": manifest["graph_hash"]},
+        )
+        mutable_store.close()
+        return {
+            "frozen_dir": str(frozen),
+            "mutable_dir": str(mutable),
+            "manifest": manifest,
+            "episodes": len(records),
+        }
+    except BaseException:
+        try:
+            store.close()
+        except Exception:
+            pass
+        if working.exists() and not recovery.exists():
+            os.replace(working, recovery)
+        raise
+
+
+def run_benchmark_tasks(
+    task_ids: Iterable[str],
+    agent_fn: AgentFn,
+    world_adapter: WorldAdapter,
+    *,
+    graph_dir: str | Path,
+    results_dir: str | Path,
+    trials: int = 1,
+    runtime: RuntimeFingerprint | None = None,
+    manifest_path: str | Path | None = None,
+    run_id: str | None = None,
+) -> list[BenchmarkResult]:
+    """Run tasks serially and synchronously settle each episode into the mutable graph."""
+
+    if trials < 1:
+        raise ValueError("trials must be >= 1")
+    run_id = run_id or _benchmark_run_id()
+    if not run_id or Path(run_id).name != run_id or run_id in {".", ".."}:
+        raise ValueError("run_id must be one path-safe component")
+    runtime = runtime or default_runtime_fingerprint()
+    graph_path = Path(graph_dir).resolve()
+    if (
+        not (graph_path / "graph.sqlite").is_file()
+        or not (graph_path / "graph_manifest.json").is_file()
+    ):
+        raise FileNotFoundError("benchmark graph is missing; run `paos minecraft warmup` first")
+    store = GraphStore(graph_path / "graph.sqlite")
+    stored_runtime = store.get_metadata("runtime")
+    if stored_runtime and stored_runtime.get("hash") != runtime.hash:
+        store.close()
+        raise RuntimeError("mutable skill graph runtime scope mismatch")
+    if not store.get_metadata("base_frozen_graph_hash"):
+        store.close()
+        raise RuntimeError("benchmark graph is not derived from a frozen warm-up graph")
+    output = Path(results_dir).resolve()
+    batch_output = output / run_id
+    results: list[BenchmarkResult] = []
+    records: list[dict[str, Any]] = []
+    try:
+        for task_id in task_ids:
+            task = load_task(task_id, manifest_path)
+            for index in range(1, trials + 1):
+                trial_id = f"{run_id}:{task.id}:trial-{index:02d}"
+                result = run_task_spec(
+                    task,
+                    _graph_agent(agent_fn, store),
+                    world_adapter,
+                    metadata={"phase": "benchmark", "run_id": run_id, "trial_id": trial_id},
+                )
+                store.record_episode(
+                    task, result, trial_id=trial_id, source="benchmark", runtime=runtime
+                )
+                sync_mutable_graph(
+                    store,
+                    graph_path,
+                    runtime,
+                    extra={
+                        "origin": "benchmark_online",
+                        "base_frozen_graph_hash": store.get_metadata("base_frozen_graph_hash"),
+                    },
+                )
+                record = _result_record(result, trial_id=trial_id)
+                _atomic_json(batch_output / task.id / f"trial-{index:02d}.json", record)
+                records.append(record)
+                results.append(result)
+    finally:
+        store.close()
+    _atomic_json(batch_output / "summary.json", records)
+    return results

--- a/PhyAgentOS/game_agents/minecraft/store.py
+++ b/PhyAgentOS/game_agents/minecraft/store.py
@@ -1,0 +1,489 @@
+"""SQLite evidence ledger, claim registry, retrieval, and graph snapshots."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sqlite3
+import stat
+import tempfile
+from pathlib import Path
+from typing import Any, Mapping
+
+from PhyAgentOS.benchmarks.minecraft.techtree.evaluator import inventory_counts
+from PhyAgentOS.benchmarks.minecraft.techtree.schema import TechTreeTask
+
+from .model import Claim, Evidence, Node, RuntimeFingerprint, canonical_hash, canonical_json
+
+SCHEMA_VERSION = 1
+
+
+def _atomic_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _action_sequence(agent_result: Any) -> list[Mapping[str, Any]]:
+    if not isinstance(agent_result, Mapping):
+        return []
+    actions = agent_result.get("actions")
+    if isinstance(actions, list):
+        return [dict(item) for item in actions if isinstance(item, Mapping)]
+    results = agent_result.get("results")
+    if isinstance(results, list):
+        return [
+            dict(item["action"])
+            for item in results
+            if isinstance(item, Mapping) and isinstance(item.get("action"), Mapping)
+        ]
+    return []
+
+
+class GraphStore:
+    """One durable transaction per observed episode."""
+
+    def __init__(self, path: str | Path, *, readonly: bool = False) -> None:
+        self.path = Path(path).resolve()
+        self.readonly = readonly
+        if readonly:
+            self.conn = sqlite3.connect(f"{self.path.as_uri()}?mode=ro&immutable=1", uri=True)
+        else:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            self.conn = sqlite3.connect(self.path)
+            self.conn.executescript(
+                """
+                PRAGMA journal_mode=DELETE;
+                PRAGMA synchronous=FULL;
+                CREATE TABLE IF NOT EXISTS metadata (
+                  key TEXT PRIMARY KEY, value_json TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS nodes (
+                  node_id TEXT PRIMARY KEY, node_type TEXT NOT NULL,
+                  canonical_key TEXT NOT NULL, attributes_json TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS evidence (
+                  evidence_id TEXT PRIMARY KEY, episode_id TEXT NOT NULL,
+                  trial_id TEXT NOT NULL, task_id TEXT NOT NULL, source TEXT NOT NULL,
+                  outcome TEXT NOT NULL, payload_json TEXT NOT NULL,
+                  runtime_fingerprint TEXT NOT NULL, confounded INTEGER NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS claims (
+                  claim_id TEXT PRIMARY KEY, edge_type TEXT NOT NULL,
+                  subject_node_id TEXT NOT NULL, object_node_id TEXT NOT NULL,
+                  action_json TEXT NOT NULL, preconditions_json TEXT NOT NULL,
+                  effects_json TEXT NOT NULL, scope_json TEXT NOT NULL,
+                  outcome TEXT NOT NULL, evidence_class TEXT NOT NULL,
+                  serveable INTEGER NOT NULL, status TEXT NOT NULL,
+                  confidence REAL NOT NULL, support_json TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS claim_evidence (
+                  claim_id TEXT NOT NULL, evidence_id TEXT NOT NULL,
+                  PRIMARY KEY (claim_id, evidence_id)
+                );
+                CREATE INDEX IF NOT EXISTS idx_claim_status ON claims(status);
+                CREATE INDEX IF NOT EXISTS idx_evidence_episode ON evidence(episode_id);
+                """
+            )
+            self.set_metadata("schema_version", SCHEMA_VERSION)
+            self.conn.commit()
+        self.conn.row_factory = sqlite3.Row
+
+    def close(self) -> None:
+        if not self.readonly:
+            self.conn.commit()
+        self.conn.close()
+
+    def set_metadata(self, key: str, value: Any) -> None:
+        if self.readonly:
+            raise RuntimeError("frozen graph is read-only")
+        self.conn.execute(
+            "INSERT INTO metadata VALUES(?,?) ON CONFLICT(key) DO UPDATE SET value_json=excluded.value_json",
+            (key, canonical_json(value)),
+        )
+
+    def get_metadata(self, key: str, default: Any = None) -> Any:
+        row = self.conn.execute("SELECT value_json FROM metadata WHERE key=?", (key,)).fetchone()
+        return json.loads(row[0]) if row else default
+
+    def _node(self, node: Node) -> None:
+        self.conn.execute(
+            "INSERT OR IGNORE INTO nodes VALUES(?,?,?,?)",
+            (node.id, node.node_type, node.key, canonical_json(dict(node.attributes))),
+        )
+
+    def add(self, evidence: Evidence, claim: Claim) -> bool:
+        if self.readonly:
+            raise RuntimeError("frozen graph is read-only")
+        before = self.conn.total_changes
+        with self.conn:
+            self.conn.execute(
+                "INSERT OR IGNORE INTO evidence VALUES(?,?,?,?,?,?,?,?,?)",
+                (
+                    evidence.id,
+                    evidence.episode_id,
+                    evidence.trial_id,
+                    evidence.task_id,
+                    evidence.source,
+                    evidence.outcome,
+                    canonical_json(dict(evidence.payload)),
+                    evidence.runtime_fingerprint,
+                    int(evidence.confounded),
+                ),
+            )
+            self._node(claim.subject)
+            self._node(claim.object)
+            self.conn.execute(
+                "INSERT OR IGNORE INTO claims VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                (
+                    claim.id,
+                    claim.edge_type,
+                    claim.subject.id,
+                    claim.object.id,
+                    canonical_json(dict(claim.action)),
+                    canonical_json(dict(claim.preconditions)),
+                    canonical_json(dict(claim.effects)),
+                    canonical_json(dict(claim.scope)),
+                    claim.outcome,
+                    claim.evidence_class,
+                    int(claim.serveable),
+                    "candidate",
+                    0.5,
+                    "{}",
+                ),
+            )
+            self.conn.execute(
+                "INSERT OR IGNORE INTO claim_evidence VALUES(?,?)", (claim.id, evidence.id)
+            )
+            self._refresh(claim.id)
+        return self.conn.total_changes > before
+
+    def _refresh(self, claim_id: str) -> None:
+        rows = self.conn.execute(
+            """SELECT DISTINCT e.trial_id,e.episode_id,e.confounded
+               FROM claim_evidence ce JOIN evidence e USING(evidence_id)
+               WHERE ce.claim_id=?""",
+            (claim_id,),
+        ).fetchall()
+        usable = [row for row in rows if not bool(row["confounded"])]
+        trials = sorted({row["trial_id"] for row in usable})
+        episodes = sorted({row["episode_id"] for row in usable})
+        confidence = 1.0 if trials else 0.0
+        status = "verified" if trials else "quarantined"
+        support = {
+            "observed_trials": trials,
+            "episodes": episodes,
+            "observation_count": len(trials),
+            "verification_policy": "single_observation",
+            "backend_seed_control": False,
+        }
+        self.conn.execute(
+            "UPDATE claims SET status=?,confidence=?,support_json=? WHERE claim_id=?",
+            (status, confidence, canonical_json(support), claim_id),
+        )
+
+    def record_episode(
+        self,
+        task: TechTreeTask,
+        result: Any,
+        *,
+        trial_id: str,
+        source: str,
+        runtime: RuntimeFingerprint,
+    ) -> bool:
+        """Synchronously persist one warm-up or benchmark experience."""
+
+        sequence = _action_sequence(result.agent_result)
+        signature = canonical_hash(sequence or [{"task": task.id}], "action")
+        success = bool(result.success)
+        failure = result.verdict.reason if not success else None
+        initial = inventory_counts(result.initial_observation or {})
+        final = inventory_counts(result.final_observation or {})
+        payload = {
+            "task": task.to_dict(),
+            "success": success,
+            "reward": result.reward,
+            "error": result.error,
+            "verdict": result.verdict.to_dict(),
+            "initial_inventory": initial,
+            "final_inventory": final,
+            "actions": sequence,
+            "backend_seed_control": False,
+        }
+        evidence = Evidence(
+            episode_id=f"{source}:{task.id}:{trial_id}",
+            trial_id=trial_id,
+            task_id=task.id,
+            source=source,
+            outcome="success" if success else f"failure:{failure}",
+            payload=payload,
+            runtime_fingerprint=runtime.hash,
+            confounded=bool(result.error),
+        )
+        subject = Node("SkillAction", signature, {"actions": sequence, "task_family": task.family})
+        if success:
+            object_node = Node(
+                "Goal", f"inventory:{task.target_item}>={task.success_criterion.count}"
+            )
+            effects: Mapping[str, Any] = {
+                "inventory_contains": {task.target_item: task.success_criterion.count}
+            }
+            outcome = "state_transition_success"
+        else:
+            object_node = Node("FailurePattern", str(failure or "unknown_failure"))
+            effects = {"failure_pattern": str(failure or "unknown_failure")}
+            outcome = "observed_failure"
+        claim = Claim(
+            edge_type="TRANSITION",
+            subject=subject,
+            object=object_node,
+            action={"signature": signature, "sequence": sequence},
+            preconditions={"inventory": initial, "family": task.family},
+            effects=effects,
+            scope={"runtime_fingerprint": runtime.hash, "backend": "mineflayer_http"},
+            outcome=outcome,
+            evidence_class=f"{source}_episode",
+            serveable=not bool(result.error),
+        )
+        return self.add(evidence, claim)
+
+    def counts(self) -> dict[str, Any]:
+        statuses = dict(self.conn.execute("SELECT status,COUNT(*) FROM claims GROUP BY status"))
+        return {
+            "evidence": self.conn.execute("SELECT COUNT(*) FROM evidence").fetchone()[0],
+            "nodes": self.conn.execute("SELECT COUNT(*) FROM nodes").fetchone()[0],
+            "claims": self.conn.execute("SELECT COUNT(*) FROM claims").fetchone()[0],
+            "claim_statuses": statuses,
+        }
+
+    def claims(self, *, status: str | None = None) -> list[dict[str, Any]]:
+        where = " WHERE c.status=?" if status else ""
+        args = (status,) if status else ()
+        query = (
+            "SELECT c.*,s.node_type s_type,s.canonical_key s_key,s.attributes_json s_attrs,"
+            "o.node_type o_type,o.canonical_key o_key,o.attributes_json o_attrs "
+            "FROM claims c JOIN nodes s ON s.node_id=c.subject_node_id "
+            "JOIN nodes o ON o.node_id=c.object_node_id" + where + " ORDER BY c.claim_id"
+        )
+        output = []
+        for row in self.conn.execute(query, args):
+            output.append(
+                {
+                    "claim_id": row["claim_id"],
+                    "edge_type": row["edge_type"],
+                    "subject": {
+                        "node_id": row["subject_node_id"],
+                        "node_type": row["s_type"],
+                        "key": row["s_key"],
+                        "attributes": json.loads(row["s_attrs"]),
+                    },
+                    "object": {
+                        "node_id": row["object_node_id"],
+                        "node_type": row["o_type"],
+                        "key": row["o_key"],
+                        "attributes": json.loads(row["o_attrs"]),
+                    },
+                    "action": json.loads(row["action_json"]),
+                    "preconditions": json.loads(row["preconditions_json"]),
+                    "effects": json.loads(row["effects_json"]),
+                    "scope": json.loads(row["scope_json"]),
+                    "outcome": row["outcome"],
+                    "evidence_class": row["evidence_class"],
+                    "serveable": bool(row["serveable"]),
+                    "status": row["status"],
+                    "confidence": float(row["confidence"]),
+                    "support": json.loads(row["support_json"]),
+                }
+            )
+        return output
+
+    def serving_graph(self, runtime: RuntimeFingerprint) -> dict[str, Any]:
+        claims = [
+            claim
+            for claim in self.claims(status="verified")
+            if claim["serveable"] and claim["scope"].get("runtime_fingerprint") == runtime.hash
+        ]
+        nodes = {}
+        for claim in claims:
+            nodes[claim["subject"]["node_id"]] = claim["subject"]
+            nodes[claim["object"]["node_id"]] = claim["object"]
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "runtime_fingerprint": runtime.hash,
+            "nodes": [nodes[key] for key in sorted(nodes)],
+            "claims": claims,
+        }
+
+    def retrieve(
+        self,
+        goal: str,
+        observation: Mapping[str, Any],
+        *,
+        limit: int = 8,
+        max_chars: int = 3000,
+    ) -> tuple[str, list[str]]:
+        """Return compact verified context; live observations remain authoritative."""
+
+        normalized_goal = goal.lower().replace(".", " ").replace("_", " ")
+        terms = {term for term in normalized_goal.split() if len(term) > 2}
+        inventory = set(inventory_counts(observation))
+        ranked = []
+        for claim in self.claims(status="verified"):
+            if not claim["serveable"]:
+                continue
+            haystack = canonical_json(
+                {
+                    "action": claim["action"],
+                    "object": claim["object"]["key"],
+                    "effects": claim["effects"],
+                }
+            ).lower()
+            score = 5 * sum(term in haystack for term in terms)
+            score += sum(item in haystack for item in inventory)
+            ranked.append((-score, claim["claim_id"], claim))
+        lines: list[str] = []
+        ids: list[str] = []
+        for _, claim_id, claim in sorted(ranked):
+            line = (
+                f"{claim['action']['signature']} with {claim['preconditions']} -> "
+                f"{claim['effects']} (confidence={claim['confidence']:.2f})"
+            )
+            if sum(map(len, lines)) + len(line) > max_chars:
+                continue
+            lines.append(f"{len(lines) + 1}. {line}")
+            ids.append(claim_id)
+            if len(lines) == limit:
+                break
+        if not lines:
+            return "", []
+        header = "VERIFIED SKILL GRAPH (observations override learned claims):\n"
+        return header + "\n".join(lines), ids
+
+    def evidence_jsonl(self) -> str:
+        lines = []
+        for row in self.conn.execute("SELECT * FROM evidence ORDER BY evidence_id"):
+            value = dict(row)
+            value["payload"] = json.loads(value.pop("payload_json"))
+            value["confounded"] = bool(value["confounded"])
+            lines.append(canonical_json(value))
+        return "".join(f"{line}\n" for line in lines)
+
+
+def _artifact_payload(
+    store: GraphStore,
+    runtime: RuntimeFingerprint,
+    extra: Mapping[str, Any] | None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    serving = store.serving_graph(runtime)
+    graph_hash = canonical_hash(serving, "graph")
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "graph_hash": graph_hash,
+        "runtime": runtime.to_dict(),
+        "counts": store.counts(),
+        "backend_seed_control": False,
+        **dict(extra or {}),
+    }
+    return {**serving, "graph_hash": graph_hash}, manifest
+
+
+def sync_mutable_graph(
+    store: GraphStore,
+    artifact_dir: str | Path,
+    runtime: RuntimeFingerprint,
+    *,
+    extra: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    if store.readonly:
+        raise RuntimeError("cannot sync a frozen graph")
+    artifact = Path(artifact_dir).resolve()
+    serving, manifest = _artifact_payload(store, runtime, extra)
+    _atomic_text(
+        artifact / "serving_graph.json",
+        json.dumps(serving, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
+    )
+    _atomic_text(artifact / "evidence.jsonl", store.evidence_jsonl())
+    _atomic_text(
+        artifact / "graph_manifest.json",
+        json.dumps(manifest, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
+    )
+    _atomic_text(artifact / "graph.sha256", manifest["graph_hash"] + "\n")
+    return manifest
+
+
+def freeze_graph(
+    store: GraphStore,
+    artifact_dir: str | Path,
+    runtime: RuntimeFingerprint,
+    *,
+    extra: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    artifact = Path(artifact_dir).resolve()
+    if store.path.parent != artifact:
+        raise ValueError("graph.sqlite must be inside the artifact directory")
+    manifest = sync_mutable_graph(store, artifact, runtime, extra=extra)
+    store.close()
+    for path in artifact.iterdir():
+        if path.is_file():
+            path.chmod(stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+    artifact.chmod(
+        stat.S_IRUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH
+    )
+    return manifest
+
+
+def load_frozen_graph(
+    artifact_dir: str | Path,
+    runtime: RuntimeFingerprint,
+    *,
+    expected_hash: str | None = None,
+) -> tuple[GraphStore, dict[str, Any]]:
+    artifact = Path(artifact_dir).resolve()
+    manifest = json.loads((artifact / "graph_manifest.json").read_text(encoding="utf-8"))
+    serving = json.loads((artifact / "serving_graph.json").read_text(encoding="utf-8"))
+    declared = serving.pop("graph_hash", None)
+    actual = canonical_hash(serving, "graph")
+    if declared != actual or manifest.get("graph_hash") != actual:
+        raise RuntimeError("skill graph content hash mismatch")
+    if expected_hash and expected_hash != actual:
+        raise RuntimeError(f"skill graph hash mismatch: expected {expected_hash}, got {actual}")
+    if manifest.get("runtime", {}).get("hash") != runtime.hash:
+        raise RuntimeError("skill graph runtime scope mismatch")
+    return GraphStore(artifact / "graph.sqlite", readonly=True), manifest
+
+
+def clone_frozen_graph(source: str | Path, destination: str | Path) -> GraphStore:
+    source_path = Path(source).resolve()
+    destination_path = Path(destination).resolve()
+    if destination_path.exists():
+        raise FileExistsError(destination_path)
+    shutil.copytree(source_path, destination_path)
+    destination_path.chmod(
+        stat.S_IRUSR
+        | stat.S_IWUSR
+        | stat.S_IXUSR
+        | stat.S_IRGRP
+        | stat.S_IXGRP
+        | stat.S_IROTH
+        | stat.S_IXOTH
+    )
+    for path in destination_path.iterdir():
+        if path.is_file():
+            path.chmod(stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
+    store = GraphStore(destination_path / "graph.sqlite")
+    store.set_metadata("base_frozen_graph_hash", (source_path / "graph.sha256").read_text().strip())
+    store.set_metadata("artifact_role", "benchmark_mutable")
+    store.conn.commit()
+    return store

--- a/PhyAgentOS/game_agents/minecraft/warmup_manifest.json
+++ b/PhyAgentOS/game_agents/minecraft/warmup_manifest.json
@@ -1,0 +1,71 @@
+{
+  "schema_version": 1,
+  "case_order": ["W01", "W02", "W03", "W04", "W05", "W06", "W07"],
+  "trials": ["trial-01"],
+  "backend_seed_control": false,
+  "tasks": [
+    {
+      "id": "W01",
+      "tier": "Warmup",
+      "family": "dig_pickup",
+      "title": "Collect birch log",
+      "target_item": "birch_log",
+      "success_criterion": {"type": "inventory_contains", "item": "birch_log", "count": 1},
+      "setup": {"clear_inventory": true, "inventory": [{"item": "wooden_axe", "count": 1}], "blocks": [{"block": "birch_log", "relative": [2, 0, 0]}]}
+    },
+    {
+      "id": "W02",
+      "tier": "Warmup",
+      "family": "crafting_inventory",
+      "title": "Craft birch planks",
+      "target_item": "birch_planks",
+      "success_criterion": {"type": "inventory_contains", "item": "birch_planks", "count": 1},
+      "setup": {"clear_inventory": true, "inventory": [{"item": "birch_log", "count": 1}]}
+    },
+    {
+      "id": "W03",
+      "tier": "Warmup",
+      "family": "crafting_inventory",
+      "title": "Craft birch button",
+      "target_item": "birch_button",
+      "success_criterion": {"type": "inventory_contains", "item": "birch_button", "count": 1},
+      "setup": {"clear_inventory": true, "inventory": [{"item": "birch_planks", "count": 1}]}
+    },
+    {
+      "id": "W04",
+      "tier": "Warmup",
+      "family": "crafting_table",
+      "title": "Craft bowl",
+      "target_item": "bowl",
+      "success_criterion": {"type": "inventory_contains", "item": "bowl", "count": 1},
+      "setup": {"clear_inventory": true, "inventory": [{"item": "oak_planks", "count": 3}, {"item": "crafting_table", "count": 1}]}
+    },
+    {
+      "id": "W05",
+      "tier": "Warmup",
+      "family": "crafting_table",
+      "title": "Craft wooden hoe",
+      "target_item": "wooden_hoe",
+      "success_criterion": {"type": "inventory_contains", "item": "wooden_hoe", "count": 1},
+      "setup": {"clear_inventory": true, "inventory": [{"item": "oak_planks", "count": 2}, {"item": "stick", "count": 2}, {"item": "crafting_table", "count": 1}]}
+    },
+    {
+      "id": "W06",
+      "tier": "Warmup",
+      "family": "smelting",
+      "title": "Bake potato",
+      "target_item": "baked_potato",
+      "success_criterion": {"type": "inventory_contains", "item": "baked_potato", "count": 1},
+      "setup": {"clear_inventory": true, "inventory": [{"item": "potato", "count": 1}, {"item": "coal", "count": 1}, {"item": "furnace", "count": 1}]}
+    },
+    {
+      "id": "W07",
+      "tier": "Warmup",
+      "family": "crafting_table",
+      "title": "Craft iron hoe",
+      "target_item": "iron_hoe",
+      "success_criterion": {"type": "inventory_contains", "item": "iron_hoe", "count": 1},
+      "setup": {"clear_inventory": true, "inventory": [{"item": "iron_ingot", "count": 2}, {"item": "stick", "count": 2}, {"item": "crafting_table", "count": 1}]}
+    }
+  ]
+}

--- a/PhyAgentOS/game_agents/stardew/README.md
+++ b/PhyAgentOS/game_agents/stardew/README.md
@@ -1,0 +1,35 @@
+# Stardew Planner–Actor
+
+This module hosts the existing Planner–Actor workflow developed for Stardew Valley.
+It retains the `GeneralGameSkillRuntime` API and can use compatible Core game targets.
+
+## Execution
+
+Planner selects a phase goal. Actor executes one permitted primitive per round, for up to
+three rounds, and returns observed feedback. SessionRunner and TargetSessionHandle own the
+target lifecycle; step limits, deadlines, cancellation and no-progress limits bound execution.
+
+Task completion is determined by observations or target feedback. A model finish request
+alone does not prove success. Planner and Actor read separate frozen MemoryStore snapshots;
+optional consolidation records unverified candidates after the episode.
+
+## CLI
+
+```bash
+paos general-game --workspace ./workspace --target ./target.yaml --session ./session.yaml \
+  --actions ./actions.json --success-checks ./success.json --model YOUR_MODEL \
+  --api-base http://localhost:8000/v1
+```
+
+Start the game bridge separately. Provide Core TargetSpec/SessionSpec configuration and an
+action catalog. Set `GAME_AGENT_API_KEY` if the model endpoint requires authentication.
+
+## Python
+
+```python
+from PhyAgentOS.game_agents.stardew import GeneralGameSkillRuntime, register_general_game
+```
+
+See the [English guide](../../../docs/en/general-game.md) or
+[中文接入指南](../../../docs/zh/general-game.md) for configuration and registration.
+Run `python -m pytest tests/game_agents/stardew` for software integration tests.

--- a/PhyAgentOS/game_agents/stardew/__init__.py
+++ b/PhyAgentOS/game_agents/stardew/__init__.py
@@ -1,0 +1,8 @@
+"""General game hierarchy, hosted by the existing PhyAgentOS runtime."""
+
+from PhyAgentOS.game_agents.stardew.runtime import (
+    GeneralGameSkillRuntime,
+    register_general_game,
+)
+
+__all__ = ["GeneralGameSkillRuntime", "register_general_game"]

--- a/PhyAgentOS/game_agents/stardew/agent.py
+++ b/PhyAgentOS/game_agents/stardew/agent.py
@@ -1,0 +1,98 @@
+"""Structured Planner, Actor and consolidation calls using the OS provider."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from PhyAgentOS.providers.base import LLMProvider
+
+Output = TypeVar("Output", bound=BaseModel)
+
+PROMPTS = {
+    "planner": (
+        "Choose a phase goal, continue it, replan after feedback, or finish. "
+        "Plan from public observations and primitive-free loop receipts. "
+        "Actor yield is a request for your review, not proof of success. "
+        "Finish only requests termination; the target verifies task success."
+    ),
+    "actor": (
+        "Work on the current phase. Execute exactly one allowed primitive, yield "
+        "when the phase appears complete, or request replanning when blocked. "
+        "Use the latest observation and actual feedback, not predicted state. "
+        "Do not reset, close, or independently access the target."
+    ),
+    "consolidator": (
+        "Extract reusable candidate lessons from the supplied episode evidence. "
+        "Use only the requested role. Cite actual round IDs for every lesson. "
+        "Distinguish observed results from hypotheses; a model claim is not proof. "
+        "Return an empty candidate list when evidence is insufficient."
+    ),
+}
+
+
+class StructuredAgent:
+    """Request validated decisions through the configured Core provider."""
+
+    def __init__(self, provider: LLMProvider, model: str, *, call_timeout_s: float = 120) -> None:
+        if call_timeout_s <= 0:
+            raise ValueError("call_timeout_s must be positive")
+        self.provider = provider
+        self.model = model
+        self.call_timeout_s = call_timeout_s
+        self.calls = 0
+        self.usage: dict[str, int] = {}
+
+    async def request(
+        self,
+        role: str,
+        context: dict[str, Any],
+        schema: type[Output],
+        *,
+        check: Callable[[], None],
+        remaining_s: Callable[[], float],
+    ) -> Output:
+        check()
+        generation = self.provider.generation
+        messages = [
+            {"role": "system", "content": PROMPTS[role] + " Return only JSON matching the schema."},
+            {
+                "role": "user",
+                "content": json.dumps(
+                    {"context": context, "output_schema": schema.model_json_schema()},
+                    ensure_ascii=False,
+                ),
+            },
+        ]
+        self.calls += 1
+        task = asyncio.create_task(
+            self.provider.chat(
+                messages=messages,
+                model=self.model,
+                temperature=generation.temperature,
+                max_tokens=generation.max_tokens,
+                reasoning_effort=generation.reasoning_effort,
+            )
+        )
+        try:
+            async with asyncio.timeout(min(self.call_timeout_s, remaining_s())):
+                while not task.done():
+                    await asyncio.wait({task}, timeout=0.05)
+                    if not task.done():
+                        check()
+                response = await task
+            for key, value in response.usage.items():
+                self.usage[key] = self.usage.get(key, 0) + value
+            check()
+            if response.finish_reason == "error" or response.has_tool_calls:
+                raise ValueError("provider did not return a structured decision")
+            return schema.model_validate_json(response.content or "")
+        finally:
+            if not task.done():
+                task.cancel()
+            await asyncio.gather(task, return_exceptions=True)

--- a/PhyAgentOS/game_agents/stardew/loop.py
+++ b/PhyAgentOS/game_agents/stardew/loop.py
@@ -1,0 +1,273 @@
+"""Planner → bounded Actor loop → observed receipt → Planner."""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Callable
+from copy import deepcopy
+from dataclasses import asdict
+from typing import Any
+
+from PhyAgentOS.game_agents.stardew.agent import Output, StructuredAgent
+from PhyAgentOS.game_agents.stardew.models import (
+    ActorDecision,
+    LoopReceipt,
+    Phase,
+    PlannerDecision,
+    RoundReceipt,
+)
+from PhyAgentOS.runtime.sessions.models import SkillRuntimeResult
+from PhyAgentOS.runtime.sessions.target_session_handle import TargetSessionHandle
+
+TaskVerifier = Callable[[dict[str, Any], dict[str, Any]], bool]
+
+
+class LoopStoppedError(Exception):
+    def __init__(self, status: str, reason: str) -> None:
+        self.status = status
+        self.reason = reason
+        super().__init__(reason)
+
+
+class GameLoop:
+    """Run bounded planning rounds through Core's public session handle."""
+
+    def __init__(
+        self,
+        agent: StructuredAgent,
+        *,
+        task: str,
+        actions: dict[str, Any],
+        memory: dict[str, str],
+        max_steps: int,
+        timeout_s: float,
+        cancelled: Callable[[], bool],
+        max_loops: int = 100,
+        max_no_progress: int = 5,
+    ) -> None:
+        if min(max_steps, max_loops, max_no_progress) < 1 or timeout_s <= 0:
+            raise ValueError("loop limits must be positive")
+        if not actions:
+            raise ValueError("an explicit action catalog is required")
+        self.agent = agent
+        self.task = task
+        self.actions = actions
+        self.memory = memory
+        self.max_steps = max_steps
+        self.max_loops = max_loops
+        self.max_no_progress = max_no_progress
+        self.deadline = time.monotonic() + timeout_s
+        self.cancelled = cancelled
+        self.steps = 0
+        self.receipts: list[LoopReceipt] = []
+        self.last_feedback: dict[str, Any] = {}
+        self._last_status: dict[str, Any] = {}
+        self._observation: dict[str, Any] = {}
+
+    def remaining_s(self) -> float:
+        return max(0.0, self.deadline - time.monotonic())
+
+    def check(self) -> None:
+        if self.cancelled():
+            raise LoopStoppedError("cancelled", "cancelled")
+        if self.remaining_s() <= 0:
+            raise LoopStoppedError("timed_out", "execute_timeout")
+
+    async def run(
+        self,
+        handle: TargetSessionHandle,
+        verify: TaskVerifier | None = None,
+    ) -> SkillRuntimeResult:
+        self._handle = handle
+        self._verify = verify
+        status, reason = "failed", "loop_limit"
+        try:
+            await self._run()
+        except LoopStoppedError as stop:
+            status, reason = stop.status, stop.reason
+        except TimeoutError:
+            status, reason = "timed_out", "model_timeout"
+        except (ValueError, TypeError):
+            reason = "invalid_decision"
+        except Exception as error:
+            # Provider/target exception messages may contain credentials.
+            reason = type(error).__name__
+        return SkillRuntimeResult(
+            status=status,
+            success=status == "succeeded",
+            error_code=None if status == "succeeded" else reason,
+            final_status={
+                **self.last_feedback,
+                "target_step_index": handle.session_state.step_index,
+            },
+            artifacts={"loop_receipts": [asdict(receipt) for receipt in self.receipts]},
+            metadata={"termination_reason": reason, "action_attempts": self.steps},
+        )
+
+    def _observe(self) -> dict[str, Any]:
+        data = dict(self._handle.observe().data)
+        data.pop("target_info", None)  # Target configuration is not model input.
+        if "sensors" in data:
+            data["sensors"] = {
+                name: sensor
+                for name, sensor in data["sensors"].items()
+                if sensor.get("kind") != "image"
+            }
+        # Adapters may expose numpy values. This loop consumes structured state.
+        self._observation = json.loads(
+            json.dumps(
+                data,
+                default=lambda value: value.tolist(),
+                allow_nan=False,
+            )
+        )
+        return self._observation
+
+    def _feedback(self) -> dict[str, Any]:
+        self._last_status = {**self._last_status, **self._handle.execution_status()}
+        status = self._last_status
+        info = status.get("info") or {}
+        error = status.get("error_code") or info.get("error_code")
+        ok = status.get("ok", info.get("ok"))
+        feedback = {
+            "done": status.get("done") is True,
+            "success": status.get("success", info.get("success")) is True,
+            "ok": False if error else ok,
+            "error_code": error,
+            "error_message": str(info.get("result") or "")[:500] if ok is False else None,
+            "reward": status.get("reward"),
+        }
+        if self._verify is not None:
+            feedback["success"] = bool(self._verify(self._observation, feedback))
+            if feedback["success"]:
+                feedback["done"] = True
+        return feedback
+
+    def _terminal(self) -> None:
+        if self.last_feedback.get("done") is True:
+            success = self.last_feedback.get("success") is True
+            raise LoopStoppedError("succeeded" if success else "failed", "target_done")
+
+    async def _request(
+        self,
+        role: str,
+        context: dict[str, Any],
+        schema: type[Output],
+    ) -> Output:
+        return await self.agent.request(
+            role,
+            context,
+            schema,
+            check=self.check,
+            remaining_s=self.remaining_s,
+        )
+
+    async def _run(self) -> None:
+        phase = None
+        phase_index = 0
+        no_progress = 0
+        for loop_index in range(1, self.max_loops + 1):
+            self.check()
+            observation = self._observe()
+            self.last_feedback = self._feedback()
+            self.check()
+            self._terminal()
+            if self.steps >= self.max_steps:
+                raise LoopStoppedError("failed", "step_limit")
+            decision = await self._request(
+                "planner",
+                {
+                    "task": self.task,
+                    "observation": observation,
+                    "phase": asdict(phase) if phase else None,
+                    "last_receipt": self.receipts[-1].planner_view() if self.receipts else None,
+                    "memory": self.memory.get("planner", ""),
+                    "steps_remaining": self.max_steps - self.steps,
+                },
+                PlannerDecision,
+            )
+            self.check()
+            if decision.decision == "finish":
+                # A model's finish claim cannot set success without target evidence.
+                self._observe()
+                self.last_feedback = self._feedback()
+                self.check()
+                self._terminal()
+                raise LoopStoppedError("failed", "unverified_finish")
+            if decision.decision == "continue_phase":
+                if phase is None or (decision.goal and decision.goal != phase.goal):
+                    raise ValueError("continue_phase requires the current, unchanged goal")
+                phase = Phase(phase.id, phase.goal, decision.max_rounds)
+            else:
+                phase_index += 1
+                phase = Phase(f"phase-{phase_index}", decision.goal, decision.max_rounds)
+            receipt = LoopReceipt(f"loop-{loop_index}", phase)
+            self.receipts.append(receipt)
+            for round_index in range(1, phase.max_rounds + 1):
+                self.check()
+                if self.steps >= self.max_steps:
+                    receipt.end_reason = "step_limit"
+                    raise LoopStoppedError("failed", "step_limit")
+                observation = self._observe()
+                self.last_feedback = self._feedback()
+                self.check()
+                self._terminal()
+                actor = await self._request(
+                    "actor",
+                    {
+                        "phase": asdict(phase),
+                        "round": round_index,
+                        "observation": observation,
+                        "previous_round": asdict(receipt.rounds[-1]) if receipt.rounds else None,
+                        "last_receipt": self.receipts[-2].planner_view()
+                        if len(self.receipts) > 1
+                        else None,
+                        "actions": self.actions,
+                        "memory": self.memory.get("actor", ""),
+                    },
+                    ActorDecision,
+                )
+                self.check()
+                if actor.decision != "execute":
+                    receipt.end_reason = actor.decision
+                    receipt.end_detail = actor.intent
+                    no_progress += 1
+                    break
+                if actor.action.type not in self.actions:
+                    raise ValueError("Actor selected an action outside the target catalog")
+                # One primitive crosses the boundary; all parameter validation stays in OS.
+                self.steps += 1
+                action = actor.action.model_dump()
+                chunk = {"actions": [action]}
+                if "observation_id" in observation:
+                    chunk["source_observation_id"] = observation["observation_id"]
+                self._last_status = self._handle.action_chunk(chunk)
+                after = self._observe()
+                self.last_feedback = self._feedback()
+                record = RoundReceipt(
+                    f"{receipt.id}/round-{round_index}",
+                    actor.intent,
+                    action,
+                    observation,
+                    after,
+                    deepcopy(self.last_feedback),
+                )
+                receipt.rounds.append(record)
+                self.check()
+                if self.last_feedback.get("done"):
+                    receipt.end_reason = "target_done"
+                self._terminal()
+                changed = record.planner_view()["changes"]
+                # Observation IDs/timestamps are transport metadata, not game progress.
+                metadata_keys = {"observation_id", "timestamp_ns", "state_version"}
+                progressed = any(key not in metadata_keys for key in changed)
+                no_progress = 0 if progressed else no_progress + 1
+                if no_progress >= self.max_no_progress:
+                    receipt.end_reason = "no_progress"
+                    raise LoopStoppedError("failed", "no_progress")
+                if self.last_feedback.get("ok") is False:
+                    receipt.end_reason = "action_failed"
+                    break
+            if no_progress >= self.max_no_progress:
+                raise LoopStoppedError("failed", "no_progress")

--- a/PhyAgentOS/game_agents/stardew/memory.py
+++ b/PhyAgentOS/game_agents/stardew/memory.py
@@ -1,0 +1,37 @@
+"""Freeze role memory per session; record evidenced candidates after execution."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from PhyAgentOS.agent.memory import MemoryStore
+from PhyAgentOS.game_agents.stardew.models import MemoryCandidate, Role
+
+
+class GameMemory:
+    """Use Core's storage API without creating another memory service.
+
+    MEMORY.md contains curated knowledge. New model lessons go to HISTORY.md
+    as unverified candidates, not directly into the next session's instructions.
+    """
+
+    def __init__(self, workspace: Path) -> None:
+        self.stores = {
+            role: MemoryStore(workspace / "game_agent" / role) for role in ("planner", "actor")
+        }
+
+    def snapshot(self) -> dict[str, str]:
+        return {role: store.read_long_term() for role, store in self.stores.items()}
+
+    def record(self, session_id: str, role: Role, candidates: list[MemoryCandidate]) -> None:
+        if not candidates:
+            return
+        if any(item.role != role for item in candidates):
+            raise ValueError("candidate role does not match memory scope")
+        entry = {
+            "session_id": session_id,
+            "status": "unverified",
+            "candidates": [item.model_dump() for item in candidates],
+        }
+        self.stores[role].append_history(json.dumps(entry, ensure_ascii=False))

--- a/PhyAgentOS/game_agents/stardew/models.py
+++ b/PhyAgentOS/game_agents/stardew/models.py
@@ -1,0 +1,110 @@
+"""Planner/Actor decisions and execution receipts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from PhyAgentOS.runtime.schemas.task_plan import ActionSpec
+
+Role = Literal["planner", "actor"]
+
+
+class DecisionModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class PlannerDecision(DecisionModel):
+    decision: Literal["new_phase", "continue_phase", "replan", "finish"]
+    goal: str = Field(default="", max_length=500)
+    reason: str = Field(min_length=1, max_length=1000)
+    max_rounds: int = Field(default=3, ge=1, le=3)
+
+    @model_validator(mode="after")
+    def require_goal(self) -> PlannerDecision:
+        if self.decision in {"new_phase", "replan"} and not self.goal.strip():
+            raise ValueError("new_phase and replan require a goal")
+        return self
+
+
+class GameAction(ActionSpec):
+    """Core's type/params action, rejecting unvalidated alternate payloads."""
+
+    model_config = ConfigDict(extra="forbid")
+    type: str = Field(min_length=1)
+
+
+class ActorDecision(DecisionModel):
+    decision: Literal["execute", "yield", "replan"]
+    intent: str = Field(min_length=1, max_length=500)
+    action: GameAction | None = None
+
+    @model_validator(mode="after")
+    def require_one_primitive(self) -> ActorDecision:
+        if self.decision == "execute":
+            if self.action is None:
+                raise ValueError("execute requires one typed action")
+        elif self.action is not None:
+            raise ValueError("control decisions cannot carry an action")
+        return self
+
+
+class MemoryCandidate(DecisionModel):
+    role: Role
+    lesson: str = Field(min_length=1, max_length=2000)
+    evidence: list[str] = Field(min_length=1, max_length=16)
+
+
+class MemoryUpdate(DecisionModel):
+    candidates: list[MemoryCandidate] = Field(default_factory=list, max_length=8)
+
+
+@dataclass
+class Phase:
+    id: str
+    goal: str
+    max_rounds: int
+
+
+@dataclass
+class RoundReceipt:
+    id: str
+    intent: str
+    action: dict[str, Any] | None
+    before: dict[str, Any]
+    after: dict[str, Any]
+    feedback: dict[str, Any]
+
+    def planner_view(self) -> dict[str, Any]:
+        """Expose observed changes, never primitive payloads or Actor memory."""
+        return {
+            "id": self.id,
+            "intent": self.intent,
+            "changes": {
+                key: {"before": self.before.get(key), "after": self.after.get(key)}
+                for key in self.before.keys() | self.after.keys()
+                if self.before.get(key) != self.after.get(key)
+            },
+            "feedback": self.feedback,
+        }
+
+
+@dataclass
+class LoopReceipt:
+    id: str
+    phase: Phase
+    rounds: list[RoundReceipt] = field(default_factory=list)
+    end_reason: str = "round_limit"
+    end_detail: str = ""
+
+    def planner_view(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "phase_id": self.phase.id,
+            "goal": self.phase.goal,
+            "end_reason": self.end_reason,
+            "end_detail": self.end_detail,
+            "rounds": [item.planner_view() for item in self.rounds],
+        }

--- a/PhyAgentOS/game_agents/stardew/runtime.py
+++ b/PhyAgentOS/game_agents/stardew/runtime.py
@@ -1,0 +1,205 @@
+"""General game builtin skill runtime and registry integration."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager, AsyncExitStack
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from PhyAgentOS.game_agents.stardew.agent import StructuredAgent
+from PhyAgentOS.game_agents.stardew.loop import GameLoop, TaskVerifier
+from PhyAgentOS.game_agents.stardew.memory import GameMemory
+from PhyAgentOS.game_agents.stardew.models import MemoryUpdate
+from PhyAgentOS.providers.base import LLMProvider
+from PhyAgentOS.runtime.schemas import AdapterPlan
+from PhyAgentOS.runtime.sessions.models import SkillContext, SkillRuntimeResult
+from PhyAgentOS.runtime.sessions.target_session_handle import TargetSessionHandle
+from PhyAgentOS.runtime.skillruntime.builtin.base import BuiltinSkillRuntime
+from PhyAgentOS.runtime.watchdog.runtime_registry import register_skill_runtime
+
+ProviderFactory = Callable[[], LLMProvider | AbstractAsyncContextManager[LLMProvider]]
+
+
+class GeneralGameSkillRuntime(BuiltinSkillRuntime):
+    """Bind the Planner/Actor loop to the Core session lifecycle."""
+
+    def __init__(
+        self,
+        provider_factory: ProviderFactory,
+        *,
+        model: str,
+        action_catalog: dict[str, Any],
+        memory: GameMemory | None = None,
+        evolve: bool = False,
+        verify: TaskVerifier | None = None,
+        call_timeout_s: float = 120,
+        max_loops: int = 100,
+        max_no_progress: int = 5,
+    ) -> None:
+        super().__init__()
+        if not callable(provider_factory):
+            raise TypeError("provider_factory must create a provider per session")
+        if not action_catalog or min(call_timeout_s, max_loops, max_no_progress) <= 0:
+            raise ValueError("an action catalog and positive runtime limits are required")
+        self.provider_factory = provider_factory
+        self.model = model
+        self.action_catalog = action_catalog
+        self.memory = memory
+        self.evolve = evolve
+        self.verify = verify
+        self.call_timeout_s = call_timeout_s
+        self.max_loops = max_loops
+        self.max_no_progress = max_no_progress
+        self._cancelled = threading.Event()
+        self._status = "idle"
+        self._loop: GameLoop | None = None
+
+    def start(self, skill_ctx: SkillContext) -> None:
+        self._cancelled.clear()
+        self._status = "running"
+        self._loop = None
+
+    def cancel(self, skill_ctx: SkillContext | None = None, reason: str = "interrupted") -> None:
+        self._cancelled.set()
+
+    def snapshot(self, skill_ctx: SkillContext | None = None) -> dict[str, Any]:
+        return {
+            "status": "cancelled" if self._cancelled.is_set() else self._status,
+            "steps": self._loop.steps if self._loop else 0,
+        }
+
+    def run_builtin_loop(
+        self,
+        skill_ctx: SkillContext,
+        target_handle: TargetSessionHandle,
+        adapter_plan: AdapterPlan,
+    ) -> SkillRuntimeResult:
+        return asyncio.run(self._run(skill_ctx, target_handle))
+
+    async def _run(self, ctx: SkillContext, handle: TargetSessionHandle) -> SkillRuntimeResult:
+        async with AsyncExitStack() as stack:
+            source = self.provider_factory()
+            provider = (
+                source
+                if isinstance(source, LLMProvider)
+                else await stack.enter_async_context(source)
+            )
+            return await self._run_session(ctx, handle, provider)
+
+    async def _run_session(
+        self,
+        ctx: SkillContext,
+        handle: TargetSessionHandle,
+        provider: LLMProvider,
+    ) -> SkillRuntimeResult:
+        agent = StructuredAgent(provider, self.model, call_timeout_s=self.call_timeout_s)
+        memory = self.memory.snapshot() if self.memory else {}
+        started = handle.session_state.started_at_ns or time.time_ns()
+        remaining = ctx.session.timeouts.execute_timeout_s - (time.time_ns() - started) / 1e9
+        if remaining <= 0:
+            self._status = "timed_out"
+            return SkillRuntimeResult(
+                status="timed_out",
+                success=False,
+                error_code="execute_timeout",
+                final_status={"target_step_index": handle.session_state.step_index},
+            )
+        loop = GameLoop(
+            agent,
+            task=ctx.task_description,
+            actions=self.action_catalog,
+            memory=memory,
+            max_steps=ctx.session.execution.max_steps,
+            timeout_s=remaining,
+            cancelled=lambda: self._cancelled.is_set() or handle.session_state.cancelled,
+            max_loops=self.max_loops,
+            max_no_progress=self.max_no_progress,
+        )
+        self._loop = loop
+        result = await loop.run(handle, self.verify)
+        warnings = []
+        if self.evolve and result.status in {"succeeded", "failed"} and loop.receipts:
+            try:
+                result.artifacts["memory_candidates"] = await self._consolidate(ctx, loop, result)
+            except (Exception, asyncio.CancelledError) as error:
+                # Consolidation cannot rewrite an already observed execution outcome.
+                warnings.append(f"memory_update_skipped:{type(error).__name__}")
+        self._status = result.status
+        result.metadata.update(
+            {
+                "model_calls": agent.calls,
+                "model_usage": agent.usage,
+                "memory_mode": "evolve" if self.evolve else "frozen",
+                "warnings": warnings,
+            }
+        )
+        return result
+
+    async def _consolidate(
+        self,
+        ctx: SkillContext,
+        loop: GameLoop,
+        result: SkillRuntimeResult,
+    ) -> list[dict[str, Any]]:
+        candidates = []
+        round_ids = {item.id for receipt in loop.receipts for item in receipt.rounds}
+        # Validate both scopes before recording either one.
+        for role in ("planner", "actor"):
+            evidence = [
+                receipt.planner_view() if role == "planner" else asdict(receipt)
+                for receipt in loop.receipts
+            ]
+            update = await loop.agent.request(
+                "consolidator",
+                {
+                    "role": role,
+                    "task": ctx.task_description,
+                    "outcome": {
+                        "status": result.status,
+                        "reason": result.metadata["termination_reason"],
+                    },
+                    "memory": loop.memory.get(role, ""),
+                    "evidence": evidence,
+                },
+                MemoryUpdate,
+                check=loop.check,
+                remaining_s=loop.remaining_s,
+            )
+            for candidate in update.candidates:
+                if candidate.role != role or not set(candidate.evidence) <= round_ids:
+                    raise ValueError("memory candidate has invalid scope or evidence")
+            candidates.extend(update.candidates)
+        loop.check()
+        if self.memory:
+            for role in ("planner", "actor"):
+                self.memory.record(
+                    ctx.session.session_id, role, [item for item in candidates if item.role == role]
+                )
+        return [item.model_dump() for item in candidates]
+
+
+def register_general_game(
+    provider_factory: ProviderFactory,
+    *,
+    model: str,
+    action_catalog: dict[str, Any],
+    memory_workspace: Path | None = None,
+    **runtime_options: Any,
+) -> None:
+    """Register a factory with fresh per-session state and the existing provider."""
+    memory = GameMemory(memory_workspace) if memory_workspace is not None else None
+    register_skill_runtime(
+        "GeneralGameSkillRuntime",
+        lambda: GeneralGameSkillRuntime(
+            provider_factory,
+            model=model,
+            action_catalog=action_catalog,
+            memory=memory,
+            **runtime_options,
+        ),
+    )

--- a/PhyAgentOS/runtime/skillruntime/README.md
+++ b/PhyAgentOS/runtime/skillruntime/README.md
@@ -5,5 +5,6 @@ Runtime skills are organized by execution mode.
 - `policy/` contains `PolicySkillRuntime` implementations. These runtimes own policy-driven loops and access targets only through `TargetSessionHandle`; they do not receive raw target objects.
 - `builtin/` contains `BuiltinSkillRuntime` implementations. These runtimes own builtin or agent-interactive loops and expose target operations through the handle and target tool manifest.
 - `base.py` contains the shared `BaseSkillRuntime` lifecycle contract.
+- `PhyAgentOS/game_agents/stardew/` implements bounded Planner–Actor sessions as a `BuiltinSkillRuntime`, using the configured provider and existing game targets.
 
 Skill registry entries in `SKILLRUNTIME.md` select a concrete runtime by name and declare `runtime_kind` as `policy` or `builtin`.

--- a/PhyAgentOS/runtime/targets/game/base.py
+++ b/PhyAgentOS/runtime/targets/game/base.py
@@ -29,6 +29,7 @@ class BaseGameTarget(BaseLocalTarget):
         return {"configured": True, "session_id": session_ctx.get("session_id")}
 
     def start_session(self, session_ctx: dict[str, Any]) -> dict[str, Any]:
+        self._last_status = {}
         self.reset_step_counter()
         obs = self.observe()
         return obs
@@ -46,6 +47,7 @@ class BaseGameTarget(BaseLocalTarget):
             if last.get("done"):
                 break
         self._last_status = {
+            **last,
             "executed_steps": getattr(self, "_step_idx", 0),
             "success": bool(last.get("info", {}).get("success")),
             "done": bool(last.get("done")),
@@ -56,5 +58,6 @@ class BaseGameTarget(BaseLocalTarget):
         return getattr(self, "_last_status", {"status": "idle"})
 
     def reset(self, session_ctx: dict[str, Any]) -> dict[str, Any]:
+        self._last_status = {}
         self.reset_step_counter()
         return self.observe()

--- a/PhyAgentOS/runtime/targets/game/minecraft_target.py
+++ b/PhyAgentOS/runtime/targets/game/minecraft_target.py
@@ -18,6 +18,7 @@ import time
 from collections import Counter
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 import numpy as np
 
@@ -33,7 +34,7 @@ logger = logging.getLogger(__name__)
 FALLBACK_ACTION_TYPES = frozenset({
     "move", "look", "jump", "sneak", "sprint", "attack",
     "interact", "place", "dig", "use", "select_slot", "drop",
-    "chat", "collect", "equip", "craft",
+    "chat", "collect", "equip", "craft", "smelt",
 })
 
 
@@ -81,7 +82,15 @@ class MinecraftTarget(BaseGameTarget):
             # Default timeout covers state/health polling; actions override this
             http_timeout = float(self.config.get("http_timeout", 15.0))
             headers = {"ngrok-skip-browser-warning": "true"}
-            self._http = httpx.Client(timeout=http_timeout, verify=verify, headers=headers)
+            host = urlparse(self._bridge_url).hostname
+            local_bridge = host in {"127.0.0.1", "localhost", "::1"}
+            trust_env = bool(self.config.get("trust_env", not local_bridge))
+            self._http = httpx.Client(
+                timeout=http_timeout,
+                verify=verify,
+                headers=headers,
+                trust_env=trust_env,
+            )
         return self._http
 
     def build(self) -> None:
@@ -98,7 +107,7 @@ class MinecraftTarget(BaseGameTarget):
         except Exception as exc:
             raise TargetConnectionError(
                 f"Cannot reach mineflayer bridge at {bridge_url}: {exc}. "
-                "Ensure the bridge is running on Windows and ngrok is active."
+                "Ensure the bridge and Minecraft server are running."
             ) from exc
 
         if not data.get("bot_spawned"):
@@ -119,9 +128,8 @@ class MinecraftTarget(BaseGameTarget):
     def reset(self, session_ctx: dict[str, Any]) -> dict[str, Any]:
         if not self._built:
             raise TargetResetError("target not built")
-        self._step_idx = 0
         time.sleep(self._step_delay)
-        return self.observe()
+        return super().reset(session_ctx)
 
     def observe(self) -> dict[str, Any]:
         client = self._get_http()
@@ -160,6 +168,7 @@ class MinecraftTarget(BaseGameTarget):
             "nearby_entities": data.get("nearby_entities", []),
             "players": data.get("players", []),
             "inventory": data.get("inventory", {}),
+            "inventory_items": data.get("inventory_items", []),
             "last_chats": data.get("last_chats", []),
             "info": {
                 "position": {"x": float(self._position[0]), "y": float(self._position[1]), "z": float(self._position[2])},
@@ -170,6 +179,7 @@ class MinecraftTarget(BaseGameTarget):
                 "hunger": self._hunger,
                 "world": data.get("world", {}),
                 "player_list": data.get("player_list", []),
+                "inventory_items": data.get("inventory_items", []),
             },
         }
 
@@ -185,6 +195,7 @@ class MinecraftTarget(BaseGameTarget):
             "nearby_blocks": [],
             "nearby_entities": [],
             "inventory": {},
+            "inventory_items": [],
             "last_chats": [],
             "info": {
                 "position": {"x": float(self._position[0]), "y": float(self._position[1]), "z": float(self._position[2])},

--- a/PhyAgentOS/runtime/targets/game/stardewvalley_target.py
+++ b/PhyAgentOS/runtime/targets/game/stardewvalley_target.py
@@ -168,9 +168,8 @@ class StardewValleyTarget(BaseGameTarget):
     def reset(self, session_ctx: dict[str, Any]) -> dict[str, Any]:
         if not self._built:
             raise TargetResetError("target not built")
-        self._step_idx = 0
         time.sleep(self._step_delay)
-        return self.observe()
+        return super().reset(session_ctx)
 
     def observe(self) -> dict[str, Any]:
         client = self._get_http()
@@ -239,6 +238,7 @@ class StardewValleyTarget(BaseGameTarget):
             px_f, py_f = 0.0, 0.0
 
         return {
+            **obs,
             "image": None,
             "state": [px_f, py_f, health, energy, money],
             "inventory": obs.get("inventory", []),
@@ -273,6 +273,8 @@ class StardewValleyTarget(BaseGameTarget):
             raise TargetStepError(f"action must be str or dict, got {type(action).__name__}")
 
         result = self._post_action(action_str)
+        if result.get("fatal") is True:
+            raise TargetStepError("game bridge stopped after an uncertain execution")
         time.sleep(self._step_delay)
         self._step_idx += 1
 

--- a/PhyAgentOS/templates/configs/skillruntimes/general_game.yaml
+++ b/PhyAgentOS/templates/configs/skillruntimes/general_game.yaml
@@ -1,0 +1,10 @@
+id: general_game
+runtime: GeneralGameSkillRuntime
+runtime_kind: builtin
+loop_mode: builtin_loop
+agent_exposure: none
+supported_target_kinds: [game]
+observation_contract:
+  observation_type: structured
+supports_chunk: false
+default_replan_every: 1

--- a/README.md
+++ b/README.md
@@ -121,6 +121,17 @@ By moving embodied intelligence learning and validation into game environments, 
 
 ---
 
+### Independent game-agent workflows
+
+The [game_agents directory](PhyAgentOS/game_agents/README.md) contains separate implementations:
+
+| Module | Entry | Purpose |
+|:-------|:------|:--------|
+| [Stardew](PhyAgentOS/game_agents/stardew/README.md) | `paos general-game` | Bounded Planner–Actor sessions using Core targets and observed completion checks. |
+| [Minecraft](PhyAgentOS/game_agents/minecraft/README.md) | `paos minecraft warmup` / `benchmark` | Fixed warm-up, evidence-backed Skill Graph and synchronous benchmark accumulation. |
+
+Each workflow retains its own execution and memory policy and reuses the relevant Core interfaces.
+
 ## 🚀 5-Minute Quick Start
 
 <table>
@@ -289,6 +300,8 @@ PhyAgentOS-G/
 | [Minecraft Usage Guide](docs/scenarios/game/minecraft/1_hello.md) | Users | CLI control, action space, troubleshooting |
 | [Minecraft Agent Loop](docs/scenarios/game/minecraft/2_agent_loop.md) | Developers | Agent→Watchdog execution pipeline |
 | [Minecraft Self-Evolution](docs/scenarios/game/minecraft/3_self_evo.md) | Developers | 3-tier hierarchical memory + 9-step reflection loop |
+| [Minecraft Benchmark and Skill Graph](docs/scenarios/game/minecraft/4_benchmark.md) | Developers | Warm-up, synchronous skill accumulation, CLI/Python API, and result layout |
+| [Minecraft Local Linux Setup](docs/scenarios/game/minecraft/01_linux_start.md) | Users | Local Paper, bridge, PhyAgentOS startup, and smoke-test commands |
 
 ---
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -121,6 +121,17 @@
 
 ---
 
+### 独立游戏 Agent
+
+[game_agents 目录](PhyAgentOS/game_agents/README.md) 中分开放置两套实现：
+
+| 模块 | 入口 | 用途 |
+|:-----|:-----|:-----|
+| [星露谷](PhyAgentOS/game_agents/stardew/README.md) | `paos general-game` | 使用 Core Target 执行有限轮次的 Planner–Actor 会话，以观察验证任务完成。 |
+| [Minecraft](PhyAgentOS/game_agents/minecraft/README.md) | `paos minecraft warmup` / `benchmark` | 固定预热、证据驱动的 Skill Graph 和逐回合同步评测沉淀。 |
+
+两者分别保留原有执行流程和记忆规则，复用各自需要的 Core 接口。
+
 ## 🚀 5 分钟快速开始
 
 <table>
@@ -289,6 +300,8 @@ PhyAgentOS-G/
 | [Minecraft 使用指南](docs/scenarios/game/minecraft/1_hello.md) | 使用者 | CLI 控制、动作空间、踩坑记录 |
 | [Minecraft Agent 闭环](docs/scenarios/game/minecraft/2_agent_loop.md) | 开发者 | Agent→Watchdog 完整执行链路 |
 | [Minecraft 自进化](docs/scenarios/game/minecraft/3_self_evo.md) | 开发者 | 三层分层记忆 + 9 步反思闭环 |
+| [Minecraft Benchmark 与 Skill Graph](docs/scenarios/game/minecraft/4_benchmark.md) | 开发者 | warmup、同步 skill 沉淀、CLI/Python API 与结果格式 |
+| [Minecraft Linux 本机部署](docs/scenarios/game/minecraft/01_linux_start.md) | 使用者 | Paper、bridge、PhyAgentOS 本机启动与验收命令 |
 
 ---
 

--- a/docs/en/general-game.md
+++ b/docs/en/general-game.md
@@ -1,0 +1,90 @@
+# General Game
+
+The runtime turns a task into phase goals, bounded Actor rounds and observed execution
+receipts. It uses the existing provider, target adapters, SessionRunner, MemoryStore and
+SkillRuntimeResult. Game services, benchmarks and task data are supplied separately.
+
+```text
+TargetSpec + SessionSpec + GeneralGameSkillRuntime
+                       ↓
+              preflight → SessionRunner
+                       ↓
+        Planner → phase → Actor (1–3 rounds)
+           ↑               ↓ one ActionSpec per round
+           └── receipt ← TargetSessionHandle → game adapter
+                       ↓
+               SkillRuntimeResult
+```
+
+## Run a session
+
+Install Core with `pip install -e .`, start the target's game bridge, and provide:
+
+| File | Contents |
+|:-----|:---------|
+| `target.yaml` | A Core TargetSpec with its registered runtime, adapter and runtime contract. Include `general_game` in `supported_skillruntimes`. |
+| `session.yaml` | A SessionSpec referencing the target and `general_game`, with task description, step limit and execution timeout. |
+| `actions.json` | A nonempty map of permitted primitive action types to descriptions and parameter guidance. |
+| `success.json` | Observed completion conditions; all must hold. Required for native Stardew Valley and Minecraft targets. |
+
+```yaml
+session_id: game-session
+target_ref: configured_game
+skillruntime_ref: general_game
+task_description: Complete the configured task
+execution:
+  max_steps: 100
+timeouts:
+  execute_timeout_s: 300
+```
+
+```bash
+paos general-game --workspace ./workspace --target ./target.yaml --session ./session.yaml \
+  --actions ./actions.json --success-checks ./success.json --model YOUR_MODEL \
+  --api-base http://localhost:8000/v1
+```
+
+Set `GAME_AGENT_API_KEY` when the endpoint requires authentication. The command loads the
+packaged `templates/configs/skillruntimes/general_game.yaml`, performs preflight, and prints
+the Core SessionResult. A failed task returns exit code 1. It does not start a game server.
+
+Completion conditions use dotted observation paths and equality, for example
+`{"stardew.position": [1, 0]}`. A strict numeric upper bound uses
+`{"stardew.time": {"$lt": 1700}}`; missing or nonnumeric values fail the check.
+A model's `finish` request alone never proves success.
+
+## Python registration
+
+```python
+from PhyAgentOS.game_agents.stardew import register_general_game
+
+register_general_game(
+    provider_factory,
+    model="YOUR_MODEL",
+    action_catalog={"move": {"params": {"dx": "integer", "dy": "integer"}}},
+    verify=lambda observation, feedback: observation["stardew"]["position"] == [1, 0],
+)
+```
+
+`provider_factory` returns a fresh LLMProvider or an async context manager owning one.
+Registration creates fresh runtime state per session. Continue through the normal
+preflight, SkillRuntimeRegistry and SessionRunner; native target names are unchanged.
+Use a Python verifier for tasks that need more than simple observation comparisons.
+
+## Execution and memory
+
+Each Actor round dispatches one primitive. Session cancellation, elapsed time, step limits,
+planning limits and repeated lack of progress stop the loop. Receipts contain before/after
+observations and actual target feedback. A fatal bridge response terminates the session.
+
+Planner and Actor read separate MemoryStore snapshots under
+`workspace/game_agent/{planner,actor}/memory/`. With `--evolve`, completed execution can
+produce evidence-linked candidates in HISTORY.md; candidates stay unverified and are not
+automatically promoted to MEMORY.md. Consolidation failure does not rewrite the task result.
+
+## Validation
+
+Run `python -m pytest tests/game_agents/stardew`. Tests exercise the real Core session, adapters,
+provider API, CLI and result writer, with simulated external game/model HTTP services.
+Live gameplay requires a running game bridge and model endpoint. The loop currently consumes
+structured observations rather than raw image input.

--- a/docs/scenarios/game/minecraft/01_linux_start.md
+++ b/docs/scenarios/game/minecraft/01_linux_start.md
@@ -30,7 +30,7 @@
 
 | 组件 | 说明 |
 |------|------|
-| Java 17+ | 启动 Paper 服务端 |
+| Java 17 或 21（GA 构建） | 启动 Paper 1.20.4；版本字符串不要带 `-internal` |
 | Node.js 22+ | 启动 mineflayer bridge |
 | Python 3.11+ | 运行 PhyAgentOS |
 | Minecraft 服务端 | 推荐 `Paper 1.20.4` |
@@ -144,10 +144,12 @@ java -jar paper.jar nogui
 grep '^online-mode=' server.properties
 ```
 
-将 `server.properties` 中这一项设置为：
+将 `server.properties` 中这些项设置为：
 
 ```text
 online-mode=false
+enforce-secure-profile=false
+spawn-protection=0
 ```
 
 说明：
@@ -211,11 +213,11 @@ cp /path/to/PhyAgentOS/docs/scenarios/game/minecraft/bridge_server.js .
 }
 ```
 
-安装依赖：
+仓库已经提交 `package-lock.json`，安装依赖时使用锁文件：
 
 ```bash
 cd /home/sicko/mc_bridge
-npm install mineflayer mineflayer-pathfinder mineflayer-collectblock prismarine-viewer express canvas
+npm ci
 ```
 
 如果你只想先确认依赖是否完整，可以单独安装 `canvas` 看是否成功：
@@ -252,6 +254,15 @@ node bridge_server.js
 [bridge] Bot spawned: paos (MC 1.20.4)
 [bridge] 3D viewer (first-person) on http://localhost:3007
 ```
+
+bot 首次加入后，在 Paper 服务端控制台执行：
+
+```text
+op paos
+```
+
+普通动作不一定需要管理员权限，但 benchmark reset 会执行 `/tp`、`/fill`、
+`/give`、`/clear` 和 `/setblock`，缺少 OP 权限时无法可靠初始化 arena。
 
 说明：
 - `3001` 是 HTTP bridge API
@@ -467,3 +478,37 @@ Package 'pangocairo' not found
 4. 用 `POST /action` 做最小动作验证
 5. 打开 `http://localhost:3007` 观察 viewer
 6. 最后再接 `paos minecraft say`
+
+---
+
+## 十二、Skill Graph 预热与 benchmark
+
+这两个入口不需要 LLM provider，默认使用确定性的 Mineflayer baseline：
+
+```bash
+paos minecraft warmup \
+  --url http://127.0.0.1:3001 \
+  --output-dir outputs/minecraft-skill-graph
+
+paos minecraft benchmark \
+  --url http://127.0.0.1:3001 \
+  --graph-dir outputs/minecraft-skill-graph/benchmark_graph \
+  --output-dir outputs/minecraft-benchmark \
+  --tasks wooden.obtain_oak_log \
+  --run-id smoke-001
+```
+
+预热固定执行 W01-W07，每项一次独立 reset/trial。单次无混杂观测即可把对应的
+成功或失败 claim 标记为 `verified`，不会做第二次 seed 验证。完成后生成只读的
+`warmup_frozen/` 和从它派生的 `benchmark_graph/`。benchmark 每个 episode
+结束后同步更新后者，不生成探索任务；Mineflayer 不支持世界 seed 控制，这一点会
+写入所有 manifest 和结果。
+
+完整参数、Python API 和产物结构见 [4_benchmark.md](4_benchmark.md)。可用下面
+三条命令随时查看当前安装版本的帮助：
+
+```bash
+paos minecraft --help
+paos minecraft warmup --help
+paos minecraft benchmark --help
+```

--- a/docs/scenarios/game/minecraft/0_start.md
+++ b/docs/scenarios/game/minecraft/0_start.md
@@ -287,7 +287,7 @@ t.close()
 
 ---
 
-## 四、动作空间（16 种）
+## 四、动作空间（17 种）
 
 所有动作通过 `POST /action` 发给 bridge，bridge 用 mineflayer API 执行。
 
@@ -346,6 +346,7 @@ t.step({"type": "chat", "params": {"message": "hello"}})
 t.step({"type": "collect", "params": {"block_type": "oak_log", "count": 10}})
 t.step({"type": "craft",   "params": {"recipe_id": "crafting_table", "count": 1}})
 t.step({"type": "equip",   "params": {"item": "stone_pickaxe", "destination": "hand"}})
+t.step({"type": "smelt",   "params": {"input": "raw_iron", "fuel": "coal", "count": 1}})
 ```
 
 ---

--- a/docs/scenarios/game/minecraft/4_benchmark.md
+++ b/docs/scenarios/game/minecraft/4_benchmark.md
@@ -19,6 +19,90 @@
 
 ---
 
+## CLI：预热、运行和保存结果
+
+本机 Paper 与 bridge 的完整启动命令见 [01_linux_start.md](01_linux_start.md)。
+bridge 启动并在 Paper 控制台执行 `op paos` 后，下面两个命令均不需要 LLM
+provider。
+
+先运行固定预热：
+
+```bash
+paos minecraft warmup \
+  --url http://127.0.0.1:3001 \
+  --output-dir outputs/minecraft-skill-graph
+```
+
+预热按 W01–W07 顺序各执行一次独立 reset。单次无混杂观测即可将成功或失败
+claim 标记为 `verified`，不执行第二次 seed 验证、curriculum 或探索任务。
+Mineflayer 不支持 seed 控制，manifest 会明确记录
+`backend_seed_control=false`。
+
+运行指定 benchmark：
+
+```bash
+paos minecraft benchmark \
+  --url http://127.0.0.1:3001 \
+  --graph-dir outputs/minecraft-skill-graph/benchmark_graph \
+  --output-dir outputs/minecraft-benchmark \
+  --tasks wooden.obtain_oak_log,stone.obtain_cobblestone \
+  --trials 1 \
+  --run-id smoke-001
+```
+
+运行全部 40 个任务时用 `--all` 代替 `--tasks`：
+
+```bash
+paos minecraft benchmark \
+  --url http://127.0.0.1:3001 \
+  --graph-dir outputs/minecraft-skill-graph/benchmark_graph \
+  --output-dir outputs/minecraft-benchmark \
+  --all \
+  --trials 1 \
+  --run-id full-001
+```
+
+参数说明：
+
+| 命令 | 参数 | 说明 |
+|---|---|---|
+| `warmup` | `--output-dir/-o` | 必填；必须是尚未产生图谱的输出根目录 |
+| `warmup` | `--url/-u` | bridge URL，默认 `http://127.0.0.1:3001` |
+| `benchmark` | `--graph-dir` | 必填；预热生成的 `benchmark_graph/` |
+| `benchmark` | `--output-dir/-o` | 必填；episode 结果根目录 |
+| `benchmark` | `--tasks` | 逗号分隔 task id；默认 `wooden.obtain_oak_log` |
+| `benchmark` | `--all` | 忽略 `--tasks`，执行 manifest 中全部任务 |
+| `benchmark` | `--trials` | 每个任务运行次数，默认 1 |
+| `benchmark` | `--run-id` | 批次 ID；省略时自动生成，设置后便于复现 |
+| `benchmark` | `--url/-u` | bridge URL，默认 `http://127.0.0.1:3001` |
+
+查看安装版本的准确帮助：
+
+```bash
+paos minecraft --help
+paos minecraft warmup --help
+paos minecraft benchmark --help
+```
+
+产物结构：
+
+```text
+outputs/minecraft-skill-graph/
+├── warmup_frozen/        # 只读冻结图谱，后续 benchmark 不修改
+└── benchmark_graph/      # 从冻结图谱复制出的同步沉淀图谱
+
+outputs/minecraft-benchmark/
+└── <run-id>/
+    ├── summary.json
+    └── <task-id>/trial-01.json
+```
+
+每个 benchmark episode 结束后，会先把 evidence/claim 写入 SQLite，再原子刷新
+`serving_graph.json`、`evidence.jsonl`、`graph_manifest.json` 和
+`graph.sha256`，然后才开始下一个 episode。
+
+---
+
 ## 这个 Benchmark 测什么
 
 Tech-Tree benchmark 衡量 agent 能否沿着一条进阶路径获取标准 Minecraft 物品：
@@ -103,6 +187,27 @@ def agent_fn(task, world):
 
 result = run_task("wooden.obtain_oak_log", agent_fn, world_adapter)
 print(result.success, result.reward)
+```
+
+Skill Graph 的 Python API：
+
+```python
+from PhyAgentOS.game_agents.minecraft import (
+    build_scripted_agent,
+    run_benchmark_tasks,
+    run_warmup,
+)
+
+warmup = run_warmup(world_adapter, "outputs/minecraft-skill-graph")
+results = run_benchmark_tasks(
+    ["wooden.obtain_oak_log"],
+    build_scripted_agent,
+    world_adapter,
+    graph_dir=warmup["mutable_dir"],
+    results_dir="outputs/minecraft-benchmark",
+    trials=1,
+    run_id="smoke-001",
+)
 ```
 
 world adapter 的接口被刻意保持得很小：

--- a/docs/scenarios/game/minecraft/bridge_server.js
+++ b/docs/scenarios/game/minecraft/bridge_server.js
@@ -4,7 +4,7 @@
  * Usage:
  *   node bridge_server.js
  *
- * Env vars: MC_HOST, MC_PORT, BOT_NAME, MC_VERSION, API_PORT, VIEWER_PORT
+ * Env vars: MC_HOST, MC_PORT, BOT_NAME, MC_VERSION, BRIDGE_PORT, VIEWER_PORT
  *
  * Endpoints:
  *   GET  /health           → bot status
@@ -34,6 +34,11 @@ const BOT_NAME = process.env.BOT_NAME || 'paos';
 const API_PORT = parseInt(process.env.BRIDGE_PORT || '3001', 10);
 const VIEWER_PORT = parseInt(process.env.VIEWER_PORT || '3007', 10);
 const STATE_RADIUS = parseInt(process.env.STATE_RADIUS || '5', 10);
+const ACTION_TYPES = [
+    'move', 'look', 'jump', 'sneak', 'sprint', 'attack', 'interact',
+    'place', 'dig', 'use', 'select_slot', 'drop', 'chat', 'collect',
+    'equip', 'craft', 'smelt'
+];
 
 let bot = null, botSpawned = false, spawnTime = 0;
 let viewerStarted = false; // prismarine-viewer binds a port once; spawn fires again on respawn
@@ -427,6 +432,39 @@ function executeAction(action) {
                     })();
                     break;
                 }
+                case 'smelt': {
+                    const input = bot.inventory.items().find(i => i.name === p.input);
+                    const fuel = bot.inventory.items().find(i => i.name === (p.fuel || 'coal'));
+                    const furnaceBlock = bot.findBlock({
+                        matching: require('minecraft-data')(bot.version).blocksByName.furnace.id,
+                        maxDistance: parseInt(p.max_distance || 8, 10)
+                    });
+                    if (!input) return resolve({ ok: false, result: `no ${p.input}` });
+                    if (!fuel) return resolve({ ok: false, result: `no ${p.fuel || 'coal'}` });
+                    if (!furnaceBlock) return resolve({ ok: false, result: 'no nearby furnace' });
+                    (async () => {
+                        let furnace = null;
+                        try {
+                            const count = Math.max(1, parseInt(p.count || 1, 10));
+                            furnace = await bot.openFurnace(furnaceBlock);
+                            await furnace.putInput(input.type, null, count);
+                            await furnace.putFuel(fuel.type, null, 1);
+                            const deadline = Date.now() + Math.max(15000, parseInt(p.timeout_ms || 30000, 10));
+                            while ((!furnace.outputItem() || furnace.outputItem().count < count) && Date.now() < deadline) {
+                                await new Promise(r => setTimeout(r, 500));
+                            }
+                            const output = furnace.outputItem();
+                            if (!output || output.count < count) throw new Error('smelt timeout');
+                            const taken = await furnace.takeOutput();
+                            resolve({ ok: true, result: `smelted ${taken.count}x ${taken.name}` });
+                        } catch (e) {
+                            resolve({ ok: false, result: e?.message || String(e) });
+                        } finally {
+                            try { furnace?.close(); } catch (_) {}
+                        }
+                    })();
+                    break;
+                }
                 default: resolve({ ok: false, result: `unknown type: ${t}` });
             }
         } catch (e) { resolve({ ok: false, result: e.message }); }
@@ -499,6 +537,9 @@ async function benchmarkReset(setup) {
         const R = Math.max(1, parseInt(arena.clear_radius, 10));
         const H = Math.max(1, parseInt(arena.clear_height, 10));
         const fy = y - 1;
+        // Keep the bot alive while a possibly hostile destination chunk is
+        // loaded and replaced by the isolated arena.
+        seq.push('/gamemode creative @s');
         seq.push(`/tp @s ${x} ${y} ${z} 0 0`);
         seq.push(`/fill ${x - R} ${y} ${z - R} ${x + R} ${y + H} ${z + R} air`);
         seq.push(`/fill ${x - R} ${fy} ${z - R} ${x + R} ${fy} ${z + R} ${mcName(arena.floor_block)}`);
@@ -507,6 +548,10 @@ async function benchmarkReset(setup) {
         seq.push(`/fill ${x - R} ${fy} ${z + R} ${x + R} ${fy} ${z + R} ${b}`);
         seq.push(`/fill ${x - R} ${fy} ${z - R} ${x - R} ${fy} ${z + R} ${b}`);
         seq.push(`/fill ${x + R} ${fy} ${z - R} ${x + R} ${fy} ${z + R} ${b}`);
+        // The first teleport loads the destination chunks; return to the
+        // origin after the floor exists so client-side physics cannot leave
+        // the bot below the arena during setup.
+        seq.push(`/tp @s ${x} ${y} ${z} 0 0`);
     }
     if (setup.clear_inventory !== false) seq.push('/clear @s');
     for (const it of (setup.inventory || [])) seq.push(giveCmd(it));
@@ -514,6 +559,9 @@ async function benchmarkReset(setup) {
         const rel = blk.relative || [0, 0, 0];
         seq.push(`/setblock ${x + parseInt(rel[0], 10)} ${y + parseInt(rel[1], 10)} ${z + parseInt(rel[2], 10)} ${mcName(blk.block)}`);
     }
+    seq.push('/gamemode survival @s');
+    seq.push('/effect give @s minecraft:instant_health 1 10 true');
+    seq.push('/effect give @s minecraft:saturation 1 10 true');
 
     currentPhase = 'reset';
     phaseCounters = { resets: phaseCounters.resets + 1, steps: 0 };
@@ -523,7 +571,7 @@ async function benchmarkReset(setup) {
 }
 
 // ── HTTP ────────────────────────────────────────────────────────
-app.get('/health', (_req, res) => res.json({ ok: true, bot_spawned: botSpawned, uptime_seconds: botSpawned ? Math.floor((Date.now() - spawnTime) / 1000) : 0 }));
+app.get('/health', (_req, res) => res.json({ ok: true, bot_spawned: botSpawned, actions: ACTION_TYPES, uptime_seconds: botSpawned ? Math.floor((Date.now() - spawnTime) / 1000) : 0 }));
 app.get('/state', (_req, res) => res.json(getState()));
 app.post('/action', async (req, res) => {
     if (!req.body?.type) return res.status(400).json({ ok: false, error: 'missing type' });

--- a/docs/scenarios/game/minecraft/en/deployment.md
+++ b/docs/scenarios/game/minecraft/en/deployment.md
@@ -242,7 +242,7 @@ t.close()
 
 ---
 
-## 4. Action Space (16 types)
+## 4. Action Space (17 types)
 
 All actions sent to bridge via `POST /action`; bridge executes via mineflayer API.
 
@@ -310,6 +310,9 @@ t.step({"type": "craft",   "params": {"recipe_id": "crafting_table", "count": 1}
 
 # Equip item
 t.step({"type": "equip",   "params": {"item": "stone_pickaxe", "destination": "hand"}})
+
+# Smelt with a nearby furnace
+t.step({"type": "smelt",   "params": {"input": "raw_iron", "fuel": "coal", "count": 1}})
 ```
 
 ---

--- a/docs/scenarios/game/minecraft/package-lock.json
+++ b/docs/scenarios/game/minecraft/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "canvas": "^3.2.3",
         "express": "^5.2.1",
         "mineflayer": "^4.37.1",
         "mineflayer-collectblock": "^1.6.0",
@@ -193,6 +194,55 @@
         "node": "^4.5.0 || >= 5.9"
       }
     },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -296,6 +346,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/canvas": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.3.tgz",
+      "integrity": "sha512-PzE5nJZPz72YUAfo8oTp0u3fqqY7IzlTubneAihqDYAUcBk7ryeCmBbdJBEdaH0bptSOe2VT2Zwcb3UaFyaSWw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.0.0",
+        "prebuild-install": "^7.1.3"
+      },
+      "engines": {
+        "node": "^18.12.0 || >= 20.9.0"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/commander": {
       "version": "2.20.3",
@@ -431,6 +501,30 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -448,6 +542,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/discontinuous-range": {
@@ -492,6 +595,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/endian-toggle": {
@@ -649,6 +761,15 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/express": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
@@ -743,6 +864,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -788,6 +915,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -885,6 +1018,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
@@ -1087,6 +1226,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minecraft-data": {
       "version": "3.110.2",
       "resolved": "https://registry.npmjs.org/minecraft-data/-/minecraft-data-3.110.2.tgz",
@@ -1196,6 +1347,21 @@
         "prismarine-nbt": "^2.0.0"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/mojangson": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mojangson/-/mojangson-2.0.4.tgz",
@@ -1215,6 +1381,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
     },
     "node_modules/nearley": {
@@ -1247,6 +1419,24 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/node-abi": {
+      "version": "3.96.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.96.0.tgz",
+      "integrity": "sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -1345,6 +1535,33 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/prismarine-auth": {
@@ -1480,7 +1697,6 @@
       "resolved": "https://registry.npmjs.org/prismarine-registry/-/prismarine-registry-1.12.0.tgz",
       "integrity": "sha512-OC5U6YrflY6OcAWRZEqe2HGZuNp0bIuP7H+oKEHD6rLfKNDxo8Ymx5eh2VvrZWnMVugpwID1Qj/UjA4MoCzNDw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minecraft-data": "^3.70.0",
         "prismarine-block": "^1.17.1",
@@ -1863,6 +2079,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -1928,6 +2154,21 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
       }
     },
     "node_modules/readable-stream": {
@@ -2142,6 +2383,51 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -2269,6 +2555,57 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/three": {
       "version": "0.128.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.128.0.tgz",
@@ -2302,6 +2639,18 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/type-is": {
       "version": "2.1.0",
@@ -2369,6 +2718,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/docs/scenarios/game/minecraft/package.json
+++ b/docs/scenarios/game/minecraft/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "canvas": "^3.2.3",
     "express": "^5.2.1",
     "mineflayer": "^4.37.1",
     "mineflayer-collectblock": "^1.6.0",

--- a/docs/scenarios/game/minecraft/zh/deployment.md
+++ b/docs/scenarios/game/minecraft/zh/deployment.md
@@ -135,7 +135,7 @@ $env:MC_HOST="localhost"
 $env:MC_PORT="25565"
 $env:BOT_NAME="paos"
 $env:MC_VERSION="1.20.4"
-$env:API_PORT="3001"
+$env:BRIDGE_PORT="3001"
 $env:VIEWER_PORT="3007"
 node bridge_server.js
 ```
@@ -242,7 +242,7 @@ t.close()
 
 ---
 
-## 四、动作空间（16 种）
+## 四、动作空间（17 种）
 
 所有动作通过 `POST /action` 发给 bridge，bridge 用 mineflayer API 执行。
 
@@ -310,6 +310,9 @@ t.step({"type": "craft",   "params": {"recipe_id": "crafting_table", "count": 1}
 
 # 装备物品
 t.step({"type": "equip",   "params": {"item": "stone_pickaxe", "destination": "hand"}})
+
+# 使用附近熔炉烧炼
+t.step({"type": "smelt",   "params": {"input": "raw_iron", "fuel": "coal", "count": 1}})
 ```
 
 ---

--- a/docs/zh/general-game.md
+++ b/docs/zh/general-game.md
@@ -1,0 +1,85 @@
+# General Game
+
+本运行时将任务转化为阶段目标，通过有限轮次的 Actor 执行，再把真实观察和执行回执
+交回 Planner。模型、Target 适配器、SessionRunner、MemoryStore 和 SkillRuntimeResult
+均使用 Core 现有接口。游戏服务、benchmark 和任务数据由部署方提供。
+
+```text
+TargetSpec + SessionSpec + GeneralGameSkillRuntime
+                       ↓
+              preflight → SessionRunner
+                       ↓
+        Planner → 阶段 → Actor（1–3 轮）
+           ↑               ↓ 每轮一个 ActionSpec
+           └── 回执 ← TargetSessionHandle → game adapter
+                       ↓
+               SkillRuntimeResult
+```
+
+## 启动会话
+
+执行 `pip install -e .` 安装 Core，启动目标游戏桥接服务，再准备以下配置：
+
+| 文件 | 内容 |
+|:-----|:-----|
+| `target.yaml` | Core TargetSpec，引用已注册的 runtime、adapter 和有效 runtime contract；`supported_skillruntimes` 包含 `general_game`。 |
+| `session.yaml` | Core SessionSpec，引用目标和 `general_game`，设置任务描述、步数及执行超时。 |
+| `actions.json` | 非空对象，键为允许的原语动作类型，值为动作描述和参数说明。 |
+| `success.json` | 基于观察的成功条件，所有条件必须成立。原生星露谷和 Minecraft Target 必须提供。 |
+
+```yaml
+session_id: game-session
+target_ref: configured_game
+skillruntime_ref: general_game
+task_description: Complete the configured task
+execution:
+  max_steps: 100
+timeouts:
+  execute_timeout_s: 300
+```
+
+```bash
+paos general-game --workspace ./workspace --target ./target.yaml --session ./session.yaml \
+  --actions ./actions.json --success-checks ./success.json --model YOUR_MODEL \
+  --api-base http://localhost:8000/v1
+```
+
+模型服务需要认证时设置 `GAME_AGENT_API_KEY`。命令加载包内的
+`templates/configs/skillruntimes/general_game.yaml`，通过 preflight 后交给 SessionRunner，
+输出 Core SessionResult；任务失败时退出码为 1。游戏桥接服务需要提前启动。
+
+成功条件使用观察字段的点分路径，默认精确相等，例如 `{"stardew.position": [1, 0]}`。
+严格数值上界写成 `{"stardew.time": {"$lt": 1700}}`；缺失字段、非数值和达到上界都不算成功。
+模型提出 `finish` 仅表示结束请求，不能替代任务验证。
+
+## Python 注册
+
+```python
+from PhyAgentOS.game_agents.stardew import register_general_game
+
+register_general_game(
+    provider_factory,
+    model="YOUR_MODEL",
+    action_catalog={"move": {"params": {"dx": "integer", "dy": "integer"}}},
+    verify=lambda observation, feedback: observation["stardew"]["position"] == [1, 0],
+)
+```
+
+`provider_factory` 每次返回新的 LLMProvider，或负责管理它的异步上下文管理器。
+注册函数为每个会话创建独立运行状态；后续使用既有 preflight、SkillRuntimeRegistry
+和 SessionRunner。Target 沿用原注册名称，复杂目标通过 Python 检查器实现。
+
+## 执行与记忆
+
+Actor 每轮只发一个原语；取消、时间预算、步数限制、规划次数及持续无进展都会停止循环。
+回执保留动作前后观察和真实 Target 反馈，桥接返回 `fatal` 时直接结束会话。
+
+Planner 和 Actor 分别读取 `workspace/game_agent/{planner,actor}/memory/` 下的记忆快照。
+显式启用 `--evolve` 后，会话结束时依据回执生成候选经验，写入 HISTORY.md；候选保持
+`unverified` 状态，不自动进入 MEMORY.md。候选生成失败不改写任务执行结果。
+
+## 验证范围
+
+执行 `python -m pytest tests/game_agents/stardew`。测试覆盖真实 Core 会话、适配器、Provider API、
+CLI 和结果写入，外部游戏与模型 HTTP 服务使用模拟响应。实际游戏运行仍需游戏桥接和
+模型服务；当前链路处理结构化观察，不直接消费原始图像。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,8 @@ packages = ["PhyAgentOS"]
 [tool.hatch.build]
 include = [
     "PhyAgentOS/**/*.py",
+    "PhyAgentOS/game_agents/**/*.json",
+    "PhyAgentOS/game_agents/**/*.md",
     "PhyAgentOS/benchmarks/**/*.json",
     "PhyAgentOS/benchmarks/**/*.md",
     "PhyAgentOS/templates/**/*.md",

--- a/tests/game_agents/minecraft/test_skill_graph.py
+++ b/tests/game_agents/minecraft/test_skill_graph.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from PhyAgentOS.benchmarks.minecraft.techtree import list_tasks
+from PhyAgentOS.benchmarks.minecraft.techtree.schema import WorldSetup
+from PhyAgentOS.game_agents.minecraft import (
+    GraphStore,
+    RuntimeFingerprint,
+    canonical_hash,
+    load_frozen_graph,
+    run_benchmark_tasks,
+    run_warmup,
+)
+from PhyAgentOS.game_agents.minecraft.runner import (
+    build_scripted_agent,
+    load_warmup_tasks,
+)
+
+RUNTIME = RuntimeFingerprint(
+    {
+        "skill_graph_protocol": 1,
+        "minecraft_version": "1.20.4",
+        "backend": "mineflayer_http",
+        "backend_seed_control": False,
+        "claim_verification_policy": "single_observation",
+        "fixture": True,
+    }
+)
+
+
+class FakeWorld:
+    def __init__(self, *, fail_reset: bool = False) -> None:
+        self.inventory: dict[str, int] = {}
+        self.fail_reset = fail_reset
+        self.resets = 0
+
+    def reset(self, setup: WorldSetup) -> dict[str, Any]:
+        self.resets += 1
+        if self.fail_reset:
+            raise RuntimeError("reset unavailable")
+        self.inventory = {item.item: item.count for item in setup.inventory}
+        return self.observe()
+
+    def observe(self) -> dict[str, Any]:
+        return {
+            "inventory_items": [
+                {"name": name, "count": count} for name, count in self.inventory.items()
+            ]
+        }
+
+    def execute_action(self, action_type: str, params: dict[str, Any]) -> dict[str, Any]:
+        if action_type == "collect":
+            drops = {
+                "stone": "cobblestone",
+                "iron_ore": "raw_iron",
+                "gold_ore": "raw_gold",
+                "redstone_ore": "redstone",
+            }
+            item = drops.get(params["block_type"], params["block_type"])
+            self.inventory[item] = self.inventory.get(item, 0) + int(params.get("count", 1))
+        elif action_type == "craft":
+            item = params["recipe_id"]
+            self.inventory[item] = self.inventory.get(item, 0) + int(params.get("count", 1))
+        elif action_type == "smelt":
+            outputs = {"raw_iron": "iron_ingot", "raw_gold": "gold_ingot", "potato": "baked_potato"}
+            item = outputs[params["input"]]
+            self.inventory[item] = self.inventory.get(item, 0) + int(params.get("count", 1))
+        return {"ok": True}
+
+
+def test_warmup_manifest_is_fixed_single_trial_and_disjoint() -> None:
+    tasks, trials = load_warmup_tasks()
+    assert [task.id for task in tasks] == [f"W{i:02d}" for i in range(1, 8)]
+    assert trials == ["trial-01"]
+    assert not ({task.target_item for task in tasks} & {task.target_item for task in list_tasks()})
+
+
+def test_warmup_freezes_and_derives_mutable_graph(tmp_path: Path) -> None:
+    world = FakeWorld()
+    output = run_warmup(world, tmp_path / "graph", runtime=RUNTIME)
+
+    frozen = Path(output["frozen_dir"])
+    mutable = Path(output["mutable_dir"])
+    assert world.resets == 7
+    assert output["episodes"] == 7
+    assert not frozen.stat().st_mode & stat.S_IWUSR
+    assert not (frozen / "graph.sqlite").stat().st_mode & stat.S_IWUSR
+    assert (frozen / "warmup_results.json").is_file()
+
+    readonly, manifest = load_frozen_graph(frozen, RUNTIME)
+    assert manifest["counts"]["evidence"] == 7
+    assert manifest["counts"]["claim_statuses"] == {"verified": 7}
+    with pytest.raises(RuntimeError, match="read-only"):
+        readonly.set_metadata("x", 1)
+    readonly.close()
+
+    working = GraphStore(mutable / "graph.sqlite")
+    assert working.get_metadata("base_frozen_graph_hash") == manifest["graph_hash"]
+    working.set_metadata("writable", True)
+    working.close()
+
+
+def test_benchmark_synchronously_accumulates_without_touching_frozen_copy(tmp_path: Path) -> None:
+    world = FakeWorld()
+    output = run_warmup(world, tmp_path / "graph", runtime=RUNTIME)
+    frozen_manifest_before = json.loads(
+        (Path(output["frozen_dir"]) / "graph_manifest.json").read_text()
+    )
+
+    results = run_benchmark_tasks(
+        ["wooden.obtain_oak_log"],
+        build_scripted_agent,
+        world,
+        graph_dir=output["mutable_dir"],
+        results_dir=tmp_path / "results",
+        trials=2,
+        runtime=RUNTIME,
+        run_id="test-run",
+    )
+
+    assert len(results) == 2 and all(result.success for result in results)
+    mutable_manifest = json.loads((Path(output["mutable_dir"]) / "graph_manifest.json").read_text())
+    assert mutable_manifest["counts"]["evidence"] == 9
+    assert mutable_manifest["counts"]["claim_statuses"]["verified"] == 8
+    assert (
+        json.loads((Path(output["frozen_dir"]) / "graph_manifest.json").read_text())
+        == frozen_manifest_before
+    )
+    assert (tmp_path / "results" / "test-run" / "wooden.obtain_oak_log" / "trial-02.json").is_file()
+    assert not list((tmp_path / "graph").rglob("*explor*"))
+
+
+def test_warmup_error_keeps_recoverable_working_graph(tmp_path: Path) -> None:
+    output = tmp_path / "graph"
+    with pytest.raises(RuntimeError, match="reset unavailable"):
+        run_warmup(FakeWorld(fail_reset=True), output, runtime=RUNTIME)
+    assert (output / "warmup_working" / "graph.sqlite").is_file()
+    assert not (output / "warmup_frozen").exists()
+
+
+def test_benchmark_runs_use_distinct_logical_trials(tmp_path: Path) -> None:
+    world = FakeWorld()
+    output = run_warmup(world, tmp_path / "graph", runtime=RUNTIME)
+    for run_id in ("batch-a", "batch-b"):
+        run_benchmark_tasks(
+            ["wooden.obtain_oak_log"],
+            build_scripted_agent,
+            world,
+            graph_dir=output["mutable_dir"],
+            results_dir=tmp_path / "results",
+            runtime=RUNTIME,
+            run_id=run_id,
+        )
+        current = GraphStore(Path(output["mutable_dir"]) / "graph.sqlite")
+        assert current.counts()["claim_statuses"] == {"verified": 8}
+        current.close()
+    mutable = GraphStore(Path(output["mutable_dir"]) / "graph.sqlite")
+    assert mutable.counts()["evidence"] == 9
+    mutable.close()
+    assert (tmp_path / "results" / "batch-a" / "summary.json").is_file()
+    assert (tmp_path / "results" / "batch-b" / "summary.json").is_file()
+
+
+def test_canonical_hash_is_order_independent() -> None:
+    assert canonical_hash({"b": 2, "a": 1}) == canonical_hash({"a": 1, "b": 2})

--- a/tests/game_agents/stardew/test_conditions.py
+++ b/tests/game_agents/stardew/test_conditions.py
@@ -1,0 +1,25 @@
+"""Verify configured completion conditions and strict numeric deadlines."""
+
+import pytest
+
+from PhyAgentOS.cli.general_game_commands import success_check
+
+
+@pytest.mark.parametrize(
+    "time, expected",
+    [(1650, True), (1700, False), (1800, False), (None, False), ("1650", False), (False, False)],
+)
+def test_success_requires_completion_before_deadline(time, expected):
+    verify = success_check({"game.score": 150, "game.time": {"$lt": 1700}})
+    observation = {"game": {"score": 150, "time": time}}
+    assert verify(observation, {}) is expected
+    observation["game"]["score"] = 0
+    assert not verify(observation, {})
+
+
+@pytest.mark.parametrize(
+    "condition", [{"$lt": "1700"}, {"$lt": True}, {"$lt": float("inf")}, {"$lt": 1700, "$gt": 0}]
+)
+def test_invalid_deadline_configuration_fails_before_starting_game(condition):
+    with pytest.raises(ValueError, match="finite numeric"):
+        success_check({"game.time": condition})

--- a/tests/game_agents/stardew/test_session.py
+++ b/tests/game_agents/stardew/test_session.py
@@ -1,0 +1,553 @@
+"""Use the actual OS lifecycle and a deterministic target/provider at its edges."""
+
+import asyncio
+import json
+import threading
+from contextlib import asynccontextmanager
+from importlib.resources import files
+
+import pytest
+import yaml
+
+from PhyAgentOS.game_agents.stardew import (
+    GeneralGameSkillRuntime,
+    register_general_game,
+)
+from PhyAgentOS.game_agents.stardew.memory import GameMemory
+from PhyAgentOS.providers.base import LLMProvider, LLMResponse
+from PhyAgentOS.runtime.adapters.base import BaseTargetAdapter
+from PhyAgentOS.runtime.adapters.factory import register_target_adapter
+from PhyAgentOS.runtime.preflight.runtime_compatibility_preflight import (
+    RuntimeCompatibilityPreflight,
+)
+from PhyAgentOS.runtime.schemas import SessionSpec, SkillRuntimeSpec, TargetSpec
+from PhyAgentOS.runtime.sessions.session_runner import SessionRunner
+from PhyAgentOS.runtime.targets.game.base import BaseGameTarget
+from PhyAgentOS.runtime.watchdog.runtime_registry import SkillRuntimeRegistry
+from PhyAgentOS.runtime.watchdog.scheduler import ScheduledSession
+
+
+def plan(decision="new_phase", **kwargs):
+    return {"decision": decision, "goal": "reach the goal", "reason": "observed state", **kwargs}
+
+
+def act(action_type="move", **kwargs):
+    return {"decision": "execute", "intent": "advance", "action": {"type": action_type}, **kwargs}
+
+
+class ScriptedProvider(LLMProvider):
+    def __init__(self, responses):
+        super().__init__()
+        self.responses = iter(responses)
+        self.contexts = []
+        self.on_call = None
+        self.request_cancelled = False
+
+    def get_default_model(self):
+        return "test-model"
+
+    async def chat(self, messages, **kwargs):
+        context = json.loads(messages[-1]["content"])["context"]
+        self.contexts.append(context)
+        if self.on_call:
+            self.on_call(context)
+        response = next(self.responses)
+        if response == "wait":
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                self.request_cancelled = True
+                raise
+        if isinstance(response, Exception):
+            raise response
+        return LLMResponse(
+            content=response if isinstance(response, str) else json.dumps(response),
+            usage={"prompt_tokens": 10, "completion_tokens": 5},
+        )
+
+
+class GridTarget(BaseGameTarget):
+    def __init__(self, goal=4, blocked=False):
+        self.goal = goal
+        self.blocked = blocked
+        self.position = 0
+        self._step_idx = 0
+        self.resets = self.closes = self.builds = 0
+        self.chunks = []
+
+    def build(self):
+        self.builds += 1
+
+    def reset_step_counter(self):
+        self._step_idx = 0
+
+    def reset(self, session_ctx):
+        self.resets += 1
+        self.position = 0
+        self.reset_step_counter()
+        self._last_status = {"done": False, "success": False}
+        return self.observe()
+
+    def observe(self):
+        return {"position": self.position, "observation_id": str(self._step_idx)}
+
+    def step(self, action):
+        self._step_idx += 1
+        if not self.blocked:
+            self.position += 1
+        return {
+            "done": self.position >= self.goal,
+            "info": {
+                "success": self.position >= self.goal,
+            },
+        }
+
+    def action_chunk(self, chunk):
+        assert chunk["source_observation_id"] == str(self._step_idx)
+        assert len(chunk["actions"]) == 1
+        self.chunks.append(chunk)
+        status = super().action_chunk(chunk)
+        status["ok"] = not self.blocked
+        return status
+
+    def cancel(self, reason):
+        pass
+
+    def close(self):
+        self.closes += 1
+
+
+class GridAdapter(BaseTargetAdapter):
+    def to_runtime_observation(self, raw_obs, target_info):
+        return {**raw_obs, "target_info": {"api_key": "do-not-expose"}}
+
+    def to_executable_action_chunk(self, action_chunk, target_info):
+        assert action_chunk["actions"][0]["type"] == "move"
+        return action_chunk
+
+
+@pytest.fixture
+def make_runner(tmp_path):
+    runners = []
+
+    def make(responses, *, goal=4, blocked=False, max_steps=20, timeout=30, **options):
+        provider = ScriptedProvider(responses)
+        register_target_adapter("target_adapter://test_grid", GridAdapter)
+        register_general_game(
+            lambda: provider, model="test-model", action_catalog={"move": "one tile"}
+        )
+        target = GridTarget(goal, blocked)
+        contract_path = tmp_path / "grid.runtime.yaml"
+        contract_path.write_text(
+            yaml.safe_dump(
+                {
+                    "version": "runtime_target_contract_v1",
+                    "target_id": "grid",
+                    "target_adapter": "target_adapter://test_grid",
+                    "safety": {"require_target_side_validation": True},
+                    "action_contract": {
+                        "id": "grid_actions",
+                        "accepted_representations": ["target_tool_call"],
+                        "shape": [1, 1],
+                        "dtype": "object",
+                        "normalized": False,
+                        "frame": "world",
+                        "control_mode": "target_tool_call",
+                        "control_hz": 1,
+                        "components": [{"name": "command", "unit": "tool_call"}],
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        spec = TargetSpec(
+            id="grid",
+            target_class="local",
+            target_kind="game",
+            workspace=str(tmp_path),
+            supported_skillruntimes=["general_game"],
+            runtime={
+                "target_runtime": "GridTarget",
+                "target_adapter": "target_adapter://test_grid",
+                "runtime_contract_ref": contract_path,
+            },
+            observation={"observation_type": "structured"},
+        )
+        skill = SkillRuntimeSpec.model_validate(
+            yaml.safe_load(
+                files("PhyAgentOS")
+                .joinpath("templates/configs/skillruntimes/general_game.yaml")
+                .read_text(encoding="utf-8"),
+            )
+        )
+        session = SessionSpec(
+            session_id="game-session",
+            target_ref=spec.id,
+            skillruntime_ref=skill.id,
+            task_description="Reach the goal",
+            execution={"max_steps": max_steps},
+            timeouts={"execute_timeout_s": timeout},
+        )
+        preflight = RuntimeCompatibilityPreflight(tmp_path).check(
+            ScheduledSession(session, spec, skill, spec.id, skill.id),
+        )
+        assert preflight.verdict == "accepted", preflight.missing_items
+        runtime = GeneralGameSkillRuntime(
+            lambda: provider,
+            model="test-model",
+            action_catalog={"move": "one tile"},
+            **options,
+        )
+        runner = SessionRunner(
+            session=session,
+            target_spec=spec,
+            skillruntime_spec=skill,
+            adapter_plan=preflight.adapter_plan,
+            target=target,
+            skill_runtime=runtime,
+            policy_client=None,
+            perception_runtime=None,
+            perception_plan=None,
+        )
+        runners.append(runner)
+        return runner, target, provider
+
+    yield make
+    for runner in runners:
+        runner.close()
+        assert runner.target.closes == 1
+
+
+def test_phase_round_feedback_chain_uses_native_session(make_runner):
+    runner, target, provider = make_runner(
+        [
+            plan(),
+            act(),
+            act(),
+            act(),
+            plan("continue_phase"),
+            act(),
+        ]
+    )
+    result = runner.start()
+    assert result.success and result.num_steps == 4
+    assert target.resets == target.builds == 1
+    assert runner.state.step_index == 4
+    receipts = result.metadata["artifacts"]["loop_receipts"]
+    assert [len(item["rounds"]) for item in receipts] == [3, 1]
+    assert receipts[0]["phase"]["id"] == receipts[1]["phase"]["id"]
+    assert provider.contexts[2]["previous_round"]["after"]["position"] == 1
+    planner_receipt = provider.contexts[4]["last_receipt"]
+    assert planner_receipt["rounds"][-1]["changes"]["position"] == {"before": 2, "after": 3}
+    assert "action" not in json.dumps(planner_receipt)
+    assert "do-not-expose" not in json.dumps(provider.contexts)
+    assert result.metadata["model_calls"] == 6
+    assert result.metadata["model_usage"]["prompt_tokens"] == 60
+
+
+def test_failed_action_returns_receipt_to_planner(make_runner):
+    runner, target, provider = make_runner(
+        [
+            plan(),
+            act(),
+            plan("replan", goal="try again"),
+            act(),
+        ],
+        goal=1,
+        blocked=True,
+    )
+
+    def unblock(context):
+        if context.get("last_receipt", {}).get("end_reason") == "action_failed":
+            target.blocked = False
+
+    # Initial planner context has a null receipt.
+    provider.on_call = lambda c: unblock(c) if c.get("last_receipt") else None
+    result = runner.start()
+    assert result.success and result.num_steps == 2
+    assert provider.contexts[2]["last_receipt"]["rounds"][0]["feedback"]["ok"] is False
+    receipts = result.metadata["artifacts"]["loop_receipts"]
+    assert receipts[0]["phase"]["id"] != receipts[1]["phase"]["id"]
+
+
+@pytest.mark.parametrize(
+    "responses",
+    [
+        [plan("finish")],
+        [plan(), {"decision": "yield", "intent": "done"}, plan("finish")],
+    ],
+)
+def test_model_finish_cannot_assert_success(make_runner, responses):
+    runner, target, _ = make_runner(responses)
+    result = runner.start()
+    assert not result.success
+    assert result.error_code == "unverified_finish"
+    assert not target.chunks
+
+
+def test_explicit_task_verifier_uses_post_action_observation(make_runner):
+    runner, _, _ = make_runner([plan(), act()], verify=lambda obs, status: obs["position"] == 1)
+    assert runner.start().success
+
+
+@pytest.mark.parametrize(
+    "responses",
+    [
+        [plan("continue_phase")],
+        [plan(max_rounds=4)],
+        [plan(), act("reset")],
+        [plan(), act(action={"type": "move", "actions": [{"type": "reset"}]})],
+        [plan(), {"decision": "yield", "intent": "stop", "action": {"type": "move"}}],
+        ["not json"],
+    ],
+)
+def test_invalid_decisions_never_reach_target(make_runner, responses):
+    runner, target, _ = make_runner(responses)
+    result = runner.start()
+    assert result.error_code == "invalid_decision"
+    assert not target.chunks
+
+
+def test_step_budget_caps_primitive_dispatch(make_runner):
+    runner, target, _ = make_runner([plan(), act(), act()], max_steps=2)
+    result = runner.start()
+    assert result.error_code == "step_limit"
+    assert len(target.chunks) == result.num_steps == 2
+
+
+def test_success_on_last_allowed_step_is_preserved(make_runner):
+    runner, _, _ = make_runner([plan(), act()], max_steps=1, goal=1)
+    assert runner.start().success
+
+
+def test_repeated_yield_cannot_spin_without_executing(make_runner):
+    runner, target, _ = make_runner(
+        [
+            plan(),
+            {"decision": "yield", "intent": "blocked"},
+            plan("continue_phase"),
+            {"decision": "yield", "intent": "blocked"},
+        ],
+        max_no_progress=2,
+    )
+    assert runner.start().error_code == "no_progress"
+    assert not target.chunks
+
+
+def test_transport_versions_do_not_count_as_progress(make_runner):
+    runner, target, _ = make_runner(
+        [
+            plan(),
+            act(),
+            plan("replan"),
+            act(),
+        ],
+        blocked=True,
+        max_no_progress=2,
+    )
+    assert runner.start().error_code == "no_progress"
+    assert len(target.chunks) == 2
+
+
+def test_cancel_after_model_reply_prevents_action_and_counts_usage(make_runner):
+    runner, target, provider = make_runner([plan(), act()])
+    provider.on_call = lambda c: runner.cancel("stop") if "round" in c else None
+    result = runner.start()
+    assert result.status == "cancelled" and not target.chunks
+    assert result.metadata["model_usage"]["prompt_tokens"] == 20
+
+
+def test_cancel_interrupts_pending_model_call(make_runner):
+    runner, target, provider = make_runner(["wait"])
+    timer = threading.Timer(0.1, runner.cancel, args=("stop",))
+    timer.start()
+    try:
+        assert runner.start().status == "cancelled"
+    finally:
+        timer.join()
+    assert provider.request_cancelled and not target.chunks
+
+
+def test_model_timeout_cancels_request_without_dispatch(make_runner):
+    runner, target, provider = make_runner(["wait"], call_timeout_s=0.05)
+    assert runner.start().status == "timed_out"
+    assert provider.request_cancelled and not target.chunks
+
+
+def test_provider_errors_are_not_exposed_as_credentials(make_runner):
+    runner, target, _ = make_runner([ConnectionError("api-key=secret")])
+    result = runner.start()
+    assert result.error_code == "ConnectionError"
+    assert "secret" not in result.model_dump_json() and not target.chunks
+
+
+def candidate(role, evidence="loop-1/round-1"):
+    return {
+        "candidates": [
+            {"role": role, "lesson": "One move advanced one tile.", "evidence": [evidence]}
+        ]
+    }
+
+
+def test_frozen_memory_is_scoped_and_never_consolidated(make_runner, tmp_path):
+    memory = GameMemory(tmp_path)
+    memory.stores["planner"].write_long_term("planner-only")
+    memory.stores["actor"].write_long_term("actor-only")
+    runner, _, provider = make_runner([plan(), act()], goal=1, memory=memory)
+    assert runner.start().success
+    assert provider.contexts[0]["memory"] == "planner-only"
+    assert provider.contexts[1]["memory"] == "actor-only"
+    assert all(not store.history_file.exists() for store in memory.stores.values())
+
+
+def test_evolution_records_candidates_after_episode_without_promoting_them(make_runner, tmp_path):
+    memory = GameMemory(tmp_path)
+    memory.stores["planner"].write_long_term("approved")
+    runner, _, provider = make_runner(
+        [
+            plan(),
+            act(),
+            candidate("planner"),
+            candidate("actor"),
+        ],
+        goal=1,
+        memory=memory,
+        evolve=True,
+    )
+    result = runner.start()
+    assert result.success
+    assert len(result.metadata["artifacts"]["memory_candidates"]) == 2
+    assert provider.contexts[2]["outcome"]["status"] == "succeeded"
+    assert "action" not in json.dumps(provider.contexts[2]["evidence"])
+    assert provider.contexts[3]["evidence"][0]["rounds"][0]["action"]["type"] == "move"
+    assert memory.stores["planner"].read_long_term() == "approved"
+    assert "unverified" in memory.stores["actor"].history_file.read_text()
+
+
+@pytest.mark.parametrize("invalid", [candidate("actor"), candidate("planner", "invented")])
+def test_invalid_memory_evidence_does_not_change_result_or_memory(make_runner, tmp_path, invalid):
+    memory = GameMemory(tmp_path)
+    runner, _, _ = make_runner([plan(), act(), invalid], goal=1, memory=memory, evolve=True)
+    result = runner.start()
+    assert result.success and result.metadata["warnings"]
+    assert all(not store.history_file.exists() for store in memory.stores.values())
+
+
+def test_memory_snapshot_does_not_change_mid_session(make_runner, tmp_path):
+    memory = GameMemory(tmp_path)
+    memory.stores["actor"].write_long_term("original")
+    runner, _, provider = make_runner([plan(), act()], goal=1, memory=memory)
+    provider.on_call = lambda c: memory.stores["actor"].write_long_term("changed externally")
+    assert runner.start().success
+    assert provider.contexts[1]["memory"] == "original"
+
+
+def test_registry_builds_distinct_runtime_instances():
+    register_general_game(
+        lambda: ScriptedProvider([]), model="test", action_catalog={"move": "one tile"}
+    )
+    registry = SkillRuntimeRegistry()
+    first = registry.build("GeneralGameSkillRuntime")
+    second = registry.build("GeneralGameSkillRuntime")
+    first.cancel()
+    assert first.snapshot()["status"] == "cancelled"
+    assert second.snapshot()["status"] == "idle"
+
+
+def test_control_reason_reaches_planner(make_runner):
+    runner, _, provider = make_runner(
+        [
+            plan(),
+            {"decision": "replan", "intent": "path is blocked"},
+            plan("replan", goal="take another path"),
+            act(),
+        ],
+        goal=1,
+    )
+    assert runner.start().success
+    assert provider.contexts[2]["last_receipt"]["end_detail"] == "path is blocked"
+
+
+def test_session_deadline_bounds_model_request(make_runner):
+    runner, target, provider = make_runner(["wait"], timeout=1, call_timeout_s=5)
+    assert runner.start().status == "timed_out"
+    assert provider.request_cancelled and not target.chunks
+
+
+def test_target_failure_is_not_model_success(make_runner):
+    runner, target, _ = make_runner([plan(), act()], goal=1)
+    original = target.action_chunk
+
+    def failed_goal(chunk):
+        status = original(chunk)
+        status["success"] = False
+        return status
+
+    target.action_chunk = failed_goal
+    result = runner.start()
+    assert not result.success and result.error_code == "target_done"
+
+
+def test_adapter_rejection_is_not_counted_as_an_executed_step(make_runner, monkeypatch):
+    runner, target, _ = make_runner([plan(), act()])
+
+    def reject(self, chunk, info):
+        raise ValueError("invalid parameters")
+
+    monkeypatch.setattr(GridAdapter, "to_executable_action_chunk", reject)
+    result = runner.start()
+    assert result.num_steps == 0 and not target.chunks
+    assert result.metadata["action_attempts"] == 1
+
+
+def test_loop_budget_bounds_successive_replans(make_runner):
+    runner, target, _ = make_runner(
+        [
+            plan(),
+            {"decision": "replan", "intent": "try a new goal"},
+        ],
+        max_loops=1,
+    )
+    assert runner.start().error_code == "loop_limit"
+    assert not target.chunks
+
+
+def test_startup_time_consumes_the_os_session_budget(make_runner):
+    runner, target, provider = make_runner([plan(), act()])
+    reset = target.reset
+
+    def slow_reset(context):
+        runner.state.started_at_ns -= 60_000_000_000
+        return reset(context)
+
+    target.reset = slow_reset
+    assert runner.start().status == "timed_out"
+    assert not provider.contexts and not target.chunks
+
+
+def test_allowed_type_cannot_smuggle_an_alternate_action_payload(make_runner):
+    runner, target, _ = make_runner(
+        [
+            plan(),
+            act(action={"type": "move", "action": "another_skill()"}),
+        ]
+    )
+    assert runner.start().error_code == "invalid_decision"
+    assert not target.chunks
+
+
+def test_provider_scope_closes_on_cancellation(make_runner):
+    runner, target, provider = make_runner(["wait"])
+    closed = []
+
+    @asynccontextmanager
+    async def factory():
+        try:
+            yield provider
+        finally:
+            closed.append(True)
+
+    runner.skill_runtime.provider_factory = factory
+    provider.on_call = lambda context: runner.cancel("stop")
+    assert runner.start().status == "cancelled"
+    assert closed == [True] and not target.chunks

--- a/tests/game_agents/stardew/test_targets.py
+++ b/tests/game_agents/stardew/test_targets.py
@@ -1,0 +1,378 @@
+"""Real Core targets, adapters and provider; mock only the external HTTP boundary."""
+
+import asyncio
+import json
+from contextlib import asynccontextmanager
+from importlib.resources import files
+
+import httpx
+import pytest
+import yaml
+
+from PhyAgentOS.cli.general_game_commands import success_check
+from PhyAgentOS.game_agents.stardew import register_general_game
+from PhyAgentOS.providers.custom_provider import CustomProvider
+from PhyAgentOS.runtime.preflight.runtime_compatibility_preflight import (
+    RuntimeCompatibilityPreflight,
+)
+from PhyAgentOS.runtime.schemas import SessionSpec, SkillRuntimeSpec, TargetSpec
+from PhyAgentOS.runtime.sessions.session_runner import SessionRunner
+from PhyAgentOS.runtime.watchdog.result_writer import ResultWriter
+from PhyAgentOS.runtime.watchdog.runtime_registry import SkillRuntimeRegistry, TargetRuntimeRegistry
+from PhyAgentOS.runtime.watchdog.scheduler import ScheduledSession
+
+from .test_session import ScriptedProvider, act, plan
+
+
+@pytest.fixture
+def core_runner(tmp_path):
+    runners = []
+
+    def make(game, provider_factory, verify, bridge, *, action_catalog=None):
+        contract = files("PhyAgentOS").joinpath(
+            f"templates/configs/runtime/contracts/{game}.runtime.yaml",
+        )
+        data = yaml.safe_load(contract.read_text(encoding="utf-8"))
+        runtime_name = "StardewValley" if game == "stardewvalley" else "Minecraft"
+        target = TargetSpec(
+            id=data["target_id"],
+            target_class="local",
+            target_kind="game",
+            workspace=str(tmp_path),
+            supported_skillruntimes=["general_game"],
+            runtime={
+                "target_runtime": f"{runtime_name}TargetRuntime",
+                "target_adapter": data["target_adapter"],
+                "runtime_contract_ref": str(contract),
+            },
+            config={"bridge_url": "http://game.test", "step_delay": 0},
+        )
+        skill = SkillRuntimeSpec(
+            id="general_game",
+            runtime="GeneralGameSkillRuntime",
+            runtime_kind="builtin",
+            loop_mode="builtin_loop",
+            supported_target_kinds=["game"],
+            observation_contract={"observation_type": "structured"},
+        )
+        session = SessionSpec(
+            session_id=f"{game}-session",
+            target_ref=target.id,
+            skillruntime_ref=skill.id,
+            task_description="Move to the next tile",
+            execution={"max_steps": 5},
+        )
+        register_general_game(
+            provider_factory,
+            model="test-model",
+            verify=verify,
+            action_catalog=action_catalog or {"move": {"params": {"dx": 1, "dy": 0}}},
+        )
+        preflight = RuntimeCompatibilityPreflight(tmp_path).check(
+            ScheduledSession(session, target, skill, target.id, skill.id),
+        )
+        assert preflight.verdict == "accepted", preflight.missing_items
+        native_target = TargetRuntimeRegistry().build(target)
+        native_target._http = httpx.Client(transport=httpx.MockTransport(bridge))
+        runner = SessionRunner(
+            session=session,
+            target_spec=target,
+            skillruntime_spec=skill,
+            adapter_plan=preflight.adapter_plan,
+            target=native_target,
+            skill_runtime=SkillRuntimeRegistry().build(skill.runtime),
+            policy_client=None,
+            perception_runtime=None,
+            perception_plan=None,
+        )
+        runners.append(runner)
+        return runner
+
+    yield make
+    for runner in runners:
+        runner.close()
+
+
+def test_fatal_bridge_error_stops_core_without_another_model_or_action_call(core_runner):
+    provider = ScriptedProvider(
+        [
+            plan(),
+            act(action={"type": "move", "params": {"dx": 1, "dy": 0}}),
+        ]
+    )
+    dispatched = []
+
+    def bridge(request):
+        if request.url.path == "/execute":
+            dispatched.append(request)
+            return httpx.Response(
+                200,
+                json={"ok": False, "fatal": True, "error": "action interrupted"},
+            )
+        return httpx.Response(200, json={"ok": True, "obs": {"position": [0, 0]}})
+
+    runner = core_runner("stardewvalley", lambda: provider, lambda obs, feedback: False, bridge)
+    result = runner.start()
+    assert result.status == "failed"
+    assert len(provider.contexts) == 2 and len(dispatched) == 1
+
+
+@pytest.mark.parametrize("game", ["stardewvalley", "minecraft"])
+def test_native_target_reset_clears_previous_session_feedback(core_runner, game):
+    def bridge(request):
+        return httpx.Response(200, json={"ok": True, "bot_spawned": True, "obs": {}})
+
+    runner = core_runner(game, lambda: ScriptedProvider([]), None, bridge)
+    target = runner.target
+    target.build()
+    target._last_status = {"done": True, "success": True, "reward": 10}
+    target._step_idx = 7
+    target.reset({})
+    assert target.execution_status() == {}
+    assert target._step_idx == 0
+
+
+def test_stardew_native_adapter_observation_action_and_failure(core_runner, tmp_path):
+    provider = ScriptedProvider(
+        [
+            plan(),
+            act(action={"type": "move", "params": {"dx": 1, "dy": 0}}),
+            plan("replan"),
+            act(action={"type": "move", "params": {"dx": 1, "dy": 0}}),
+        ]
+    )
+    state = {"position": [0, 0], "money": 500, "health": 100, "energy": 270}
+    calls = []
+
+    def bridge(request):
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"ok": True})
+        if request.url.path == "/execute":
+            calls.append(json.loads(request.content))
+            if len(calls) == 1:
+                return httpx.Response(200, json={"ok": False, "error": "path blocked"})
+            state["position"] = [1, 0]
+        return httpx.Response(200, json={"ok": True, "obs": state})
+
+    runner = core_runner(
+        "stardewvalley",
+        lambda: provider,
+        lambda obs, feedback: obs["stardew"]["position"] == [1, 0],
+        bridge,
+    )
+    result = runner.start()
+    assert result.success and result.num_steps == 2
+    assert calls == [{"action": "move(1, 0)"}] * 2
+    assert provider.contexts[0]["observation"]["stardew"]["money"] == 500
+    receipt = provider.contexts[2]["last_receipt"]
+    assert receipt["end_reason"] == "action_failed"
+    assert receipt["rounds"][0]["feedback"]["error_message"] == "path blocked"
+    writer = ResultWriter(tmp_path)
+    writer.write_episode(runner.session, runner.target_spec, runner.skillruntime_spec.id, result)
+    assert (tmp_path / result.artifact_dir).is_dir()
+    # Reusing a native target must not expose its previous success/error flags.
+    runner.target.reset({})
+    assert runner.target.execution_status() == {}
+
+
+def test_minecraft_native_numpy_observation_is_json_safe(core_runner):
+    provider = ScriptedProvider([plan(), act(action={"type": "move", "params": {"forward": 1}})])
+    state = {"position": {"x": 0, "y": 64, "z": 0}}
+    calls = []
+
+    def bridge(request):
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"bot_spawned": True})
+        if request.url.path == "/action":
+            calls.append(json.loads(request.content))
+            state["position"]["x"] = 1
+            return httpx.Response(200, json={"ok": True, "result": "moved"})
+        return httpx.Response(200, json={"bot": state, "health": 20, "hunger": 20})
+
+    runner = core_runner(
+        "minecraft",
+        lambda: provider,
+        lambda obs, feedback: obs["info"]["position"]["x"] == 1,
+        bridge,
+    )
+    result = runner.start()
+    assert result.success and result.num_steps == 1
+    assert calls == [{"type": "move", "params": {"forward": 1}}]
+    sensors = provider.contexts[0]["observation"]["sensors"]
+    assert "front_rgb" not in sensors
+    assert isinstance(sensors["proprio"]["data"], list)
+    assert len(result.model_dump_json()) < 15000
+
+
+def test_real_custom_provider_is_created_in_each_session_loop(core_runner, monkeypatch):
+    providers = []
+    contexts = []
+    original_client = httpx.AsyncClient
+
+    def model_api(request):
+        payload = json.loads(request.content)
+        context = json.loads(payload["messages"][-1]["content"])["context"]
+        contexts.append(context)
+        decision = (
+            plan()
+            if "task" in context
+            else act(
+                action={"type": "move", "params": {"dx": 1, "dy": 0}},
+            )
+        )
+        return httpx.Response(
+            200,
+            json={
+                "id": "completion",
+                "created": 1,
+                "model": "test-model",
+                "object": "chat.completion",
+                "choices": [
+                    {
+                        "index": 0,
+                        "finish_reason": "stop",
+                        "message": {
+                            "role": "assistant",
+                            "content": json.dumps(decision),
+                        },
+                    }
+                ],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+            },
+        )
+
+    class ScopedClient(original_client):
+        def __init__(self, **kwargs):
+            super().__init__(transport=httpx.MockTransport(model_api), **kwargs)
+            self.loop = asyncio.get_running_loop()
+
+        async def send(self, *args, **kwargs):
+            assert asyncio.get_running_loop() is self.loop
+            return await super().send(*args, **kwargs)
+
+        async def aclose(self):
+            assert asyncio.get_running_loop() is self.loop
+            await super().aclose()
+
+    monkeypatch.setattr(httpx, "AsyncClient", ScopedClient)
+
+    @asynccontextmanager
+    async def factory():
+        provider = CustomProvider(api_base="http://model.test/v1")
+        providers.append(provider)
+        async with provider._client:
+            yield provider
+
+    position = [0, 0]
+
+    def bridge(request):
+        if request.url.path == "/execute":
+            position[0] += 1
+        return httpx.Response(200, json={"ok": True, "obs": {"position": position}})
+
+    for _ in range(2):
+        position[0] = 0
+        runner = core_runner(
+            "stardewvalley",
+            factory,
+            lambda obs, feedback: obs["stardew"]["position"] == [1, 0],
+            bridge,
+        )
+        assert len(providers) == _  # preflight and registry construction do not open clients
+        result = runner.start()
+        assert result.success and result.metadata["model_usage"]["total_tokens"] == 30
+    assert len(providers) == 2 and len(contexts) == 4
+    assert all(provider._client.is_closed() for provider in providers)
+
+
+def test_example_completion_conditions_require_every_observed_value():
+    verify = success_check({"stardew.position": [1, 0], "stardew.current_menu": None})
+    assert verify({"stardew": {"position": [1, 0], "current_menu": None}}, {})
+    assert not verify({"stardew": {"position": [1, 0]}}, {})
+    assert not verify({"stardew": {"position": [0, 0], "current_menu": None}}, {})
+    with pytest.raises(ValueError, match="nonempty"):
+        success_check({})
+
+
+def test_example_cli_runs_native_stardew_to_verified_completion(
+    core_runner,
+    tmp_path,
+    monkeypatch,
+):
+    position = [0, 0]
+    replies = iter([plan(), act(action={"type": "move", "params": {"dx": 1, "dy": 0}})])
+
+    def http_api(request):
+        if request.url.path.endswith("/chat/completions"):
+            return httpx.Response(
+                200,
+                json={
+                    "id": "test",
+                    "created": 1,
+                    "model": "test",
+                    "object": "chat.completion",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "finish_reason": "stop",
+                            "message": {
+                                "role": "assistant",
+                                "content": json.dumps(next(replies)),
+                            },
+                        }
+                    ],
+                },
+            )
+        if request.url.path == "/execute":
+            assert json.loads(request.content) == {"action": "move(1, 0)"}
+            position[0] = 1
+        return httpx.Response(200, json={"ok": True, "obs": {"position": position}})
+
+    runner = core_runner("stardewvalley", lambda: ScriptedProvider([]), None, http_api)
+    target_data = runner.target_spec.model_dump(mode="json")
+    target_data["runtime"]["target_runtime"] = "StardewValleyTargetRuntime"
+    arguments = {
+        "target": target_data,
+        "session": runner.session.model_dump(mode="json"),
+        "actions": {"move": {"params": {"dx": 1, "dy": 0}}},
+        "success-checks": {"stardew.position": [1, 0]},
+    }
+    argv = [
+        "run_session.py",
+        "--workspace",
+        str(tmp_path),
+        "--model",
+        "test",
+        "--api-base",
+        "http://model.test/v1",
+    ]
+    for name, value in arguments.items():
+        path = tmp_path / f"{name}.json"
+        path.write_text(json.dumps(value), encoding="utf-8")
+        argv.extend([f"--{name}", str(path)])
+    sync_client, async_client = httpx.Client, httpx.AsyncClient
+    clients = []
+
+    class AsyncClient(async_client):
+        def __init__(self, **kwargs):
+            super().__init__(transport=httpx.MockTransport(http_api), **kwargs)
+            clients.append(self)
+
+    monkeypatch.setattr(httpx, "AsyncClient", AsyncClient)
+    monkeypatch.setattr(
+        httpx,
+        "Client",
+        lambda **kw: sync_client(
+            transport=httpx.MockTransport(http_api),
+            **kw,
+        ),
+    )
+    from typer.testing import CliRunner
+
+    from PhyAgentOS.cli.commands import app
+
+    response = CliRunner().invoke(app, ["general-game", *argv[1:]])
+    assert response.exit_code == 0, response.output
+    result = json.loads(response.stdout)
+    assert result["success"] and result["num_steps"] == 1
+    assert all(client.is_closed for client in clients)


### PR DESCRIPTION
Superseded by #108, which preserves the same commit and targets the same branch from the contributor's fork. The temporary upstream source branch is being removed.

Add the Stardew and Minecraft agent implementations under a shared `PhyAgentOS/game_agents/` directory, with each game retaining its own execution and memory model.

```text
PhyAgentOS/game_agents/
├── stardew/     # Planner–Actor loop, Core runtime integration and role memory
└── minecraft/  # Skill graph, evidence store and warm-up execution
```

- Preserve `GeneralGameSkillRuntime`, `register_general_game` and `paos general-game` for Stardew, and `AgentFn`, `WorldAdapter`, graph APIs and `paos minecraft warmup` / `benchmark` for Minecraft. The two game modules do not import each other.
- Keep the required target, Minecraft bridge and tech-tree harness updates in their existing Core locations. Update imports, packaged resources, tests and English/Chinese documentation for the new directories.
- Include only the agent integration and its supporting changes; Clockwork Demo01, the C# mod, game saves and recorded benchmark outputs are excluded.

This is one commit against `feature/general-game-agent` at `c74eb5366d68a0e69cdd8bbc05776f6754a0fe2f`.

Validation: 107 tests passed locally; Ruff, diff checks and the Minecraft bridge JavaScript syntax check passed. A built wheel was installed separately and verified to load both modules, the W01–W07 manifest and all three CLI entry points. The same commit passed Windows and Linux CI in the preparation repository. Game and model boundaries were mocked; live game sessions have not been validated.

[Upstream CI](https://github.com/PhyAgentOS/PhyAgentOS-core/actions/runs/34046691267) passed on Windows and Linux, including tests, CLI entry points and wheel packaging.

Known issues reproduced in a subsequent review, still present in this revision:

- The Minecraft scripted executor checks top-level `ok`, while `MinecraftTargetWorldAdapter` returns action failure under `info.ok`. It can continue to place/craft after an equip failure.
- Graph evidence extraction prefers the planned `actions` list over executed `results`. After early termination it can record unexecuted actions as part of a verified failure claim.
- Frozen graph loading validates the exported JSON hash but not the SQLite contents it subsequently reads. Inconsistent JSON/database snapshots can pass the declared hash check.

These cases are not covered by the passing CI suite. This PR retains the current implementation for maintainer review; the above issues remain unresolved.
