### PR TITLE
docs: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Report a reproducible problem
+title: "[Bug] "
+labels: ""
+assignees: ""
+---
+
+<!-- Search existing issues first. Remove credentials, private URLs and sensitive data. -->
+
+## Environment
+
+- PhyAgentOS version or commit:
+- OS:
+- Python version:
+- Installation method:
+- Robot or simulator (if relevant):
+
+## Problem
+
+Describe what happened and what you expected.
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Logs
+
+```text
+Paste redacted logs here.
+```
+
+## Checklist
+
+- [ ] I searched existing issues.
+- [ ] I can reproduce this problem.
+- [ ] I removed secrets and sensitive data.
+- [ ] This is not a security vulnerability.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/PhyAgentOS/PhyAgentOS-core/security/advisories/new
+    about: Report security vulnerabilities privately. Do not open a public issue.
+  - name: Community support
+    url: https://discord.gg/YJztZ4wUM
+    about: Ask usage and troubleshooting questions in the community.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,24 @@
+---
+name: Documentation issue
+about: Report missing, incorrect or unclear documentation
+title: "[Docs] "
+labels: ""
+assignees: ""
+---
+
+## Location
+
+Provide the documentation URL or repository path.
+
+## Problem
+
+Explain what is incorrect, missing or difficult to follow.
+
+## Suggested change
+
+Describe the expected content or propose a correction.
+
+## Checklist
+
+- [ ] I checked the latest documentation and existing issues.
+- [ ] I removed secrets and sensitive information from examples and logs.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,31 @@
+---
+name: Feature request
+about: Suggest an improvement or new capability
+title: "[Feature] "
+labels: ""
+assignees: ""
+---
+
+<!-- Search existing issues before submitting. Keep the request focused on one capability. -->
+
+## Problem
+
+What user need or limitation should this feature address?
+
+## Proposed solution
+
+Describe the desired behavior and a concrete use case.
+
+## Alternatives
+
+Describe existing workarounds or alternative designs.
+
+## Additional context
+
+Note compatibility, safety, security, hardware or migration considerations.
+
+## Checklist
+
+- [ ] I searched existing issues.
+- [ ] This request describes one focused capability.
+- [ ] I am willing to help implement or test it.


### PR DESCRIPTION
## Summary
Add lightweight GitHub issue templates to improve the quality and consistency of community reports.
## Changes
- Add a bug report template with environment and reproduction fields
- Add a feature request template focused on user needs and compatibility
- Add a documentation issue template
- Disable blank issues
- Direct security vulnerabilities to private GitHub Security Advisories
- Direct general support questions to Discord
## Validation
- Verified Markdown front matter
- Verified GitHub issue template directory structure
- Confirmed no project runtime code is affected