### PR TITLE
fix(skill-runtime): profile startup timeouts, live dora flow detection, node env injection

### DIFF
--- a/PhyAgentOS/skill_runtime/installer.py
+++ b/PhyAgentOS/skill_runtime/installer.py
@@ -318,6 +318,37 @@ class NodeInstaller:
             raise InstallerError(f"invalid Forge node tar.gz archive: {exc}") from exc
 
 
+def _inject_node_environment(
+    rendered: str,
+    profile_environment: dict[str, str],
+    runtime_environment: dict[str, str],
+) -> str:
+    """Bind the launching runtime's environment to every Dora node.
+
+    Dora nodes inherit the environment of the daemon that spawns them, so a
+    pre-existing shared daemon can supply a stale HOME or
+    PAOS_SKILL_VERSION. Node-declared values win over the profile-level
+    environment, and runtime-derived identity wins over both.
+    """
+    try:
+        document = yaml.safe_load(rendered)
+    except yaml.YAMLError as exc:
+        raise InstallerError(f"rendered Skill dataflow is not valid YAML: {exc}") from exc
+    if not isinstance(document, dict) or not isinstance(document.get("nodes"), list):
+        raise InstallerError("rendered Skill dataflow must define a nodes list")
+    profile_values = {str(key): str(value) for key, value in profile_environment.items()}
+    runtime_values = {str(key): str(value) for key, value in runtime_environment.items()}
+    for node in document["nodes"]:
+        if not isinstance(node, dict):
+            raise InstallerError("rendered Skill dataflow node must be a mapping")
+        declared = node.get("env") or {}
+        if not isinstance(declared, dict):
+            raise InstallerError("rendered Skill dataflow node env must be a mapping")
+        declared_values = {str(key): str(value) for key, value in declared.items()}
+        node["env"] = {**profile_values, **declared_values, **runtime_values}
+    return yaml.safe_dump(document, sort_keys=False, allow_unicode=True)
+
+
 class SkillEnvironmentBuilder:
     """Create immutable per-Skill executable views from exact node locks."""
 
@@ -364,6 +395,9 @@ class SkillEnvironmentBuilder:
             },
             "entrypoints": sorted(required),
             "dataflow": profile.dataflow.as_posix(),
+            "environment": {
+                str(key): str(value) for key, value in profile.environment.items()
+            },
         }
         profile_files: dict[str, str] = {}
         profile_parent = skill.bundle_root / profile.dataflow.parent
@@ -410,6 +444,17 @@ class SkillEnvironmentBuilder:
                 ).replace("${PAOS_SKILL_ROOT}", str(skill.bundle_root))
                 rendered = rendered.replace("${PAOS_SKILL_NAME}", skill.name).replace(
                     "${PAOS_SKILL_VERSION}", skill.version
+                )
+                rendered = _inject_node_environment(
+                    rendered,
+                    profile.environment,
+                    {
+                        "HOME": str(Path.home()),
+                        "PAOS_SKILL_NAME": skill.name,
+                        "PAOS_SKILL_VERSION": skill.version,
+                        "PAOS_SKILL_ROOT": str(skill.bundle_root),
+                        "FORGE_RUNTIME_BIN": str((target / "bin").resolve()),
+                    },
                 )
                 (launch_profile / profile.dataflow.name).write_text(
                     rendered, encoding="utf-8"

--- a/PhyAgentOS/skill_runtime/manager.py
+++ b/PhyAgentOS/skill_runtime/manager.py
@@ -136,7 +136,11 @@ class RuntimeManager:
             self._ensure_dora_up(manifest, profile, binary_root)
             launched = True
             self._start_flow(flow_name, manifest, profile, binary_root)
-            self._wait_until_ready(manifest, flow_name)
+            self._wait_until_ready(
+                manifest,
+                flow_name,
+                timeout_s=self._startup_timeout_s(profile),
+            )
             snapshot = self._gateway_snapshot(manifest) or {}
             data = snapshot.get("data") if isinstance(snapshot.get("data"), dict) else {}
             identity = data.get("gateway_identity") or data.get("gateway_id")
@@ -481,8 +485,19 @@ class RuntimeManager:
 
         return has_running(data)
 
-    def _wait_until_ready(self, manifest: SkillManifest, flow_name: str) -> None:
-        deadline = time.monotonic() + self.health_timeout_s
+    def _startup_timeout_s(self, profile: RuntimeProfile) -> float:
+        if profile.startup_timeout_s is None:
+            return self.health_timeout_s
+        return profile.startup_timeout_s
+
+    def _wait_until_ready(
+        self,
+        manifest: SkillManifest,
+        flow_name: str,
+        *,
+        timeout_s: float,
+    ) -> None:
+        deadline = time.monotonic() + timeout_s
         last_reason = "Gateway GET /tools is unavailable"
         while time.monotonic() < deadline:
             if not self._flow_running(flow_name):

--- a/PhyAgentOS/skill_runtime/manager.py
+++ b/PhyAgentOS/skill_runtime/manager.py
@@ -465,25 +465,59 @@ class RuntimeManager:
         )
         if result.returncode != 0:
             return False
+        return self._has_active_flow(
+            self._parse_flow_list(result.stdout or ""), flow_name
+        )
+
+    @staticmethod
+    def _parse_flow_list(output: str) -> list[dict[str, Any]]:
+        """Parse ``dora list --format json`` output.
+
+        Some Dora builds emit a single JSON array; others emit NDJSON (one JSON
+        object per line). Accept both so the live flow is not misread.
+        """
+        text = (output or "").strip()
+        if not text:
+            return []
         try:
-            data = json.loads(result.stdout or "[]")
+            data = json.loads(text)
         except json.JSONDecodeError:
-            return flow_name in (result.stdout or "") and "running" in (
-                result.stdout or ""
-            ).lower()
+            data = None
+        if isinstance(data, list):
+            return [item for item in data if isinstance(item, dict)]
+        if isinstance(data, dict):
+            return [data]
+        entries: list[dict[str, Any]] = []
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                item = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(item, dict):
+                entries.append(item)
+        return entries
 
-        def has_running(value: Any) -> bool:
-            if isinstance(value, dict):
-                name_matches = value.get("name") in {None, flow_name}
-                status = str(value.get("status", "")).lower()
-                if name_matches and status == "running":
-                    return True
-                return any(has_running(item) for item in value.values())
-            if isinstance(value, list):
-                return any(has_running(item) for item in value)
+    @staticmethod
+    def _has_active_flow(flows: list[dict[str, Any]], flow_name: str) -> bool:
+        """Return True only when ``flow_name`` has a live Running flow.
+
+        Historical Dora rows with the same name linger as Finished/Failed/
+        Succeeded with ``nodes == 0``; the live flow is the running entry
+        (prefer one that reports participating nodes).
+        """
+        running: list[dict[str, Any]] = []
+        for item in flows:
+            if item.get("name") not in {None, flow_name}:
+                continue
+            if str(item.get("status", "")).lower() == "running":
+                running.append(item)
+        if not running:
             return False
-
-        return has_running(data)
+        with_nodes = [item for item in running if item.get("nodes") not in (None, 0)]
+        return bool(with_nodes) if with_nodes else True
 
     def _startup_timeout_s(self, profile: RuntimeProfile) -> float:
         if profile.startup_timeout_s is None:

--- a/PhyAgentOS/skill_runtime/manifest.py
+++ b/PhyAgentOS/skill_runtime/manifest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from math import isfinite
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -23,6 +24,7 @@ _MANIFEST_FIELDS = {
 }
 _PROFILE_FIELDS = {
     "dataflow",
+    "startup_timeout_s",
     "required_binaries",
     "required_assets",
     "required_environment",
@@ -91,11 +93,23 @@ def _path_tuple(value: Any, label: str) -> tuple[Path, ...]:
     return tuple(_relative_path(item, f"{label} item") for item in value)
 
 
+def _optional_positive_float(value: Any, label: str) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ManifestError(f"{label} must be a positive number")
+    parsed = float(value)
+    if not isfinite(parsed) or parsed <= 0:
+        raise ManifestError(f"{label} must be a positive number")
+    return parsed
+
+
 @dataclass(frozen=True)
 class RuntimeProfile:
     """One launchable Dora profile in a Skill manifest."""
 
     dataflow: Path
+    startup_timeout_s: float | None = None
     required_binaries: tuple[Path, ...] = ()
     required_assets: tuple[Path, ...] = ()
     required_environment: tuple[str, ...] = ()
@@ -114,6 +128,9 @@ class RuntimeProfile:
         }
         return cls(
             dataflow=_relative_path(data.get("dataflow"), f"{label}.dataflow"),
+            startup_timeout_s=_optional_positive_float(
+                data.get("startup_timeout_s"), f"{label}.startup_timeout_s"
+            ),
             required_binaries=_path_tuple(
                 data.get("required_binaries"), f"{label}.required_binaries"
             ),

--- a/tests/test_environment_injection.py
+++ b/tests/test_environment_injection.py
@@ -1,0 +1,78 @@
+"""Tests for per-node environment injection in rendered Skill dataflows."""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from PhyAgentOS.skill_runtime.installer import InstallerError, _inject_node_environment
+
+NL = chr(10)
+
+DATAFLOW = """nodes:
+  - id: gateway
+    path: /bin/gateway
+    args: --config gateway.yaml
+    env:
+      MUJOCO_GL: egl
+      PAOS_SKILL_VERSION: "0.0.0"
+    outputs:
+      - tool_response
+  - id: worker
+    path: /bin/worker
+"""
+
+
+def _nodes(rendered: str) -> dict:
+    return {node["id"]: node for node in yaml.safe_load(rendered)["nodes"]}
+
+
+def test_injects_profile_and_runtime_environment_into_every_node() -> None:
+    rendered = _inject_node_environment(
+        DATAFLOW,
+        {"MUJOCO_GL": "osmesa", "HF_HUB_OFFLINE": "1"},
+        {"HOME": "/tmp/runtime-home", "PAOS_SKILL_VERSION": "0.1.1"},
+    )
+    nodes = _nodes(rendered)
+    gateway_env = nodes["gateway"]["env"]
+    worker_env = nodes["worker"]["env"]
+    # Node-declared values win over the profile-level environment.
+    assert gateway_env["MUJOCO_GL"] == "egl"
+    # Profile-level values reach nodes that never declared them.
+    assert worker_env["HF_HUB_OFFLINE"] == "1"
+    assert worker_env["MUJOCO_GL"] == "osmesa"
+    # Runtime-derived identity wins over both, so a shared Dora daemon cannot
+    # leak a stale HOME or PAOS_SKILL_VERSION into the node.
+    assert gateway_env["PAOS_SKILL_VERSION"] == "0.1.1"
+    assert worker_env["HOME"] == "/tmp/runtime-home"
+    assert worker_env["PAOS_SKILL_VERSION"] == "0.1.1"
+
+
+def test_preserves_unrelated_node_fields() -> None:
+    rendered = _inject_node_environment(DATAFLOW, {}, {})
+    gateway = _nodes(rendered)["gateway"]
+    assert gateway["path"] == "/bin/gateway"
+    assert gateway["args"] == "--config gateway.yaml"
+    assert gateway["outputs"] == ["tool_response"]
+
+
+def test_rejects_dataflow_without_nodes() -> None:
+    with pytest.raises(InstallerError, match="nodes list"):
+        _inject_node_environment("path: /bin/gateway" + NL, {}, {})
+
+
+def test_rejects_invalid_yaml() -> None:
+    with pytest.raises(InstallerError, match="not valid YAML"):
+        _inject_node_environment("nodes: [", {}, {})
+
+
+def test_rejects_non_mapping_node() -> None:
+    with pytest.raises(InstallerError, match="node must be a mapping"):
+        _inject_node_environment("nodes:" + NL + "  - 1" + NL, {}, {})
+
+
+def test_rejects_non_mapping_node_environment() -> None:
+    with pytest.raises(InstallerError, match="node env must be a mapping"):
+        _inject_node_environment(
+            "nodes:" + NL + "  - id: a" + NL + "    env: 1" + NL, {}, {}
+        )

--- a/tests/test_manager_flow_running.py
+++ b/tests/test_manager_flow_running.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from PhyAgentOS.skill_runtime.manager import RuntimeManager
+
+FLOW = "paos-libero-lingbot_va"
+
+ACTIVE = (
+    '{"uuid":"a1","name":"paos-libero-lingbot_va","status":"Running","nodes":3}\n'
+    '{"uuid":"a2","name":"paos-libero-lingbot_va","status":"Failed","nodes":0}\n'
+    '{"uuid":"a3","name":"paos-libero-lingbot_va","status":"Finished","nodes":0}\n'
+    '{"uuid":"a4","name":"paos-libero-lingbot_va","status":"Succeeded","nodes":0}\n'
+)
+
+HISTORICAL = (
+    '{"name":"paos-libero-lingbot_va","status":"Finished","nodes":0}\n'
+    '{"name":"paos-libero-lingbot_va","status":"Failed","nodes":0}\n'
+    '{"name":"paos-libero-lingbot_va","status":"Succeeded","nodes":0}\n'
+)
+
+
+def test_parse_ndjson() -> None:
+    flows = RuntimeManager._parse_flow_list(ACTIVE)
+    assert len(flows) == 4
+    assert flows[0]["status"] == "Running"
+
+
+def test_parse_single_json_array() -> None:
+    flows = RuntimeManager._parse_flow_list(
+        '[{"name":"paos-libero-lingbot_va","status":"Running","nodes":3}]'
+    )
+    assert len(flows) == 1
+    assert RuntimeManager._has_active_flow(flows, FLOW) is True
+
+
+def test_active_detected_over_historical() -> None:
+    flows = RuntimeManager._parse_flow_list(ACTIVE)
+    assert RuntimeManager._has_active_flow(flows, FLOW) is True
+
+
+def test_only_historical_is_not_active() -> None:
+    flows = RuntimeManager._parse_flow_list(HISTORICAL)
+    assert RuntimeManager._has_active_flow(flows, FLOW) is False
+
+
+def test_wrong_name_is_not_active() -> None:
+    flows = RuntimeManager._parse_flow_list(
+        '{"name":"other_flow","status":"Running","nodes":3}'
+    )
+    assert RuntimeManager._has_active_flow(flows, FLOW) is False
+
+
+def test_empty_and_garbage() -> None:
+    assert RuntimeManager._has_active_flow(RuntimeManager._parse_flow_list(""), FLOW) is False
+    assert RuntimeManager._has_active_flow(RuntimeManager._parse_flow_list("not json"), FLOW) is False

--- a/tests/test_startup_timeout.py
+++ b/tests/test_startup_timeout.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from PhyAgentOS.skill_runtime.manager import RuntimeManager
+from PhyAgentOS.skill_runtime.manifest import ManifestError, RuntimeProfile
+
+
+def _manager() -> RuntimeManager:
+    manager = object.__new__(RuntimeManager)
+    manager.health_timeout_s = 30.0
+    return manager
+
+
+def test_startup_timeout_defaults_to_health_timeout() -> None:
+    profile = RuntimeProfile(dataflow=Path("dataflow.yaml"))
+    assert _manager()._startup_timeout_s(profile) == 30.0
+
+
+def test_startup_timeout_uses_profile_override() -> None:
+    profile = RuntimeProfile.from_dict(
+        {"dataflow": "dataflow.yaml", "startup_timeout_s": 90}, "profiles.demo"
+    )
+    assert _manager()._startup_timeout_s(profile) == 90.0
+
+
+@pytest.mark.parametrize("value", [0, -1, False, True, "90"])
+def test_startup_timeout_rejects_invalid_values(value: object) -> None:
+    with pytest.raises(ManifestError):
+        RuntimeProfile.from_dict(
+            {"dataflow": "dataflow.yaml", "startup_timeout_s": value}, "profiles.demo"
+        )


### PR DESCRIPTION
## Context

Running the unified LIBERO Skill (`libero`, profiles `lingbot_va` / `kai0`) through PAOS surfaced three Skill Runtime gaps in `PhyAgentOS-core`. They were validated end-to-end on a real LIBERO run (PAOS Agent -> Gateway -> LIBERO benchmark -> policy session). This PR carries only the runtime-side fixes; no benchmark or policy code.

## Changes

**1. `feat(skill-runtime): support per-profile startup timeouts`**
`RuntimeProfile` had no way to express a startup budget longer than `RuntimeManager.health_timeout_s` (30s, not configurable from the CLI). The LingBot-VA profile measured ~35.1s to ready, so a healthy Skill could never pass readiness. Adds an optional positive `startup_timeout_s`, falling back to `health_timeout_s` when unset so existing Skills keep their behavior.

**2. `fix(skill-runtime): detect live dora flow from NDJSON list output`**
`dora list --format json` emits NDJSON on current Dora builds. The old code parsed the whole stdout as one JSON document, fell back to a substring check, and could treat historical `Finished`/`Failed` rows with `nodes=0` as the live flow. During a healthy run `paos skill status` could therefore report failed/down. Both a JSON array and NDJSON are now parsed, and only a `Running` entry (preferring one that reports participating nodes) counts.

**3. `fix(skill-runtime): bind profile environment to rendered dataflow nodes`**
`profile.environment` was only passed to the `dora start` subprocess. Nodes spawned by a pre-existing shared dora daemon inherit the daemon environment, so a stale `HOME` / `PAOS_SKILL_VERSION` could leak into nodes. The environment is now injected into every node of the rendered dataflow at prepare time (node-declared values win over profile values; runtime-derived identity wins over both) and recorded in `runtime-lock.json`.

`forge_task` JSON serialization was reported alongside these, but current `main` already serializes with `task.model_dump(mode="json", exclude_none=True)`, so no change is included for it.

## Verification

- `pytest tests/test_startup_timeout.py tests/test_manager_flow_running.py tests/test_environment_injection.py` -> 19 passed (Python 3.12).
- `ruff check` on every changed file -> All checks passed.
- `python -m compileall -q PhyAgentOS tests` -> OK.
- End-to-end on the real LIBERO run with a candidate runtime built from these changes: `lingbot_va` 1/1 episode succeeded; `kai0` two independent 1/1 episodes succeeded; ordinary `paos skill stop` (no `--force`) released the flow.
- `tests/test_forge_task_tool_serialization.py` contains `async def` tests requiring `pytest-asyncio`; the validation environment lacks that plugin, so those two pre-existing tests error with "async def functions are not natively supported". Unrelated to this change.

## Relation to LIBERO

Required so the unified LIBERO Skill manifest (`startup_timeout_s: 900`, `profile.environment` for EGL/offline HuggingFace settings) loads and runs on upstream defaults. No benchmark or policy node code is touched here.
