### PR TITLE
feat(skill-runtime): support directory_tar_gz Forge node archives

### DIFF
--- a/PhyAgentOS/cli/commands.py
+++ b/PhyAgentOS/cli/commands.py
@@ -1433,7 +1433,7 @@ def forge_node_install(
         help="Independently obtained local Node .tar.gz instead of a Registry download",
     ),
 ):
-    """Download the exact single-executable archive pinned by a Skill lock."""
+    """Download the exact node archive pinned by a Skill lock."""
     from PhyAgentOS.skill_runtime.catalog import SkillCatalog
     from PhyAgentOS.skill_runtime.installer import NodeInstaller
     from PhyAgentOS.skill_runtime.registry import DownloadCache, RegistryClient

--- a/PhyAgentOS/skill_runtime/archive.py
+++ b/PhyAgentOS/skill_runtime/archive.py
@@ -89,8 +89,14 @@ class ArchiveValidator:
 
     manifest_names = ("archive-manifest.json", ".paos-manifest.json")
 
-    def __init__(self, limits: ArchiveLimits | None = None) -> None:
+    def __init__(
+        self,
+        limits: ArchiveLimits | None = None,
+        *,
+        allow_internal_links: bool = False,
+    ) -> None:
         self.limits = limits or ArchiveLimits()
+        self.allow_internal_links = allow_internal_links
 
     def extract(
         self,
@@ -112,6 +118,7 @@ class ArchiveValidator:
                 if len(members) > self.limits.max_files:
                     raise ArchiveError("archive exceeds member count limit")
                 files: dict[str, tarfile.TarInfo] = {}
+                links: dict[str, str] = {}
                 seen: set[str] = set()
                 collision_keys: dict[str, str] = {}
                 total_size = 0
@@ -127,8 +134,40 @@ class ArchiveValidator:
                             f"archive paths collide after normalization: {previous}, {path}"
                         )
                     collision_keys[collision_key] = path
-                    if member.issym() or member.islnk():
-                        raise ArchiveError(f"links are forbidden in archives: {path}")
+                    if member.islnk():
+                        raise ArchiveError(f"hard links are forbidden in archives: {path}")
+                    if member.issym():
+                        if not self.allow_internal_links:
+                            raise ArchiveError(f"links are forbidden in archives: {path}")
+                        target = member.linkname
+                        if (
+                            not target
+                            or target.startswith("/")
+                            or "\x00" in target
+                            or "\\" in target
+                            or PurePosixPath(target).is_absolute()
+                        ):
+                            raise ArchiveError(
+                                f"symbolic link must be relative: {path} -> {target!r}"
+                            )
+                        if ".." in PurePosixPath(target).parts:
+                            raise ArchiveError(
+                                f"symbolic link must stay inside the archive: {path} -> {target!r}"
+                            )
+                        resolved = PurePosixPath(path).parent.joinpath(target)
+                        normalized = PurePosixPath(
+                            *(
+                                part
+                                for part in resolved.parts
+                                if part not in {"", "."}
+                            )
+                        )
+                        if ".." in normalized.parts:
+                            raise ArchiveError(
+                                f"symbolic link must stay inside the archive: {path} -> {target!r}"
+                            )
+                        links[path] = target
+                        continue
                     if not (member.isfile() or member.isdir()):
                         raise ArchiveError(f"special archive member is forbidden: {path}")
                     if member.isfile():
@@ -165,11 +204,15 @@ class ArchiveValidator:
 
                 for member in members:
                     path = _safe_path(member.name)
-                    if path.as_posix() in self.manifest_names:
+                    if verify_manifest and path.as_posix() in self.manifest_names:
+                        continue
+                    if member.issym():
                         continue
                     target = destination.joinpath(*path.parts)
                     if member.isdir():
                         target.mkdir(parents=True, exist_ok=True)
+                        continue
+                    if member.islnk():
                         continue
                     target.parent.mkdir(parents=True, exist_ok=True)
                     source = tar.extractfile(member)
@@ -200,6 +243,27 @@ class ArchiveValidator:
                         raise ArchiveError(f"file sha256 mismatch: {path.as_posix()}")
                     safe_mode = member.mode & 0o755
                     os.chmod(target, safe_mode or 0o600, follow_symlinks=False)
+                for path, target_name in sorted(links.items()):
+                    link_path = destination.joinpath(*PurePosixPath(path).parts)
+                    link_path.parent.mkdir(parents=True, exist_ok=True)
+                    try:
+                        os.symlink(target_name, link_path)
+                    except FileExistsError as exc:
+                        raise ArchiveError(
+                            f"symbolic link collides with an extracted member: {path}"
+                        ) from exc
+                for path in sorted(links):
+                    if not os.path.exists(destination.joinpath(*PurePosixPath(path).parts)):
+                        raise ArchiveError(
+                            f"symbolic link is dangling or cyclic: {path} -> {links[path]!r}"
+                        )
+                resolved_root = os.path.realpath(destination)
+                for path in sorted(links):
+                    link_path = destination.joinpath(*PurePosixPath(path).parts)
+                    if not os.path.realpath(link_path).startswith(resolved_root + os.sep):
+                        raise ArchiveError(
+                            f"symbolic link resolves outside the archive: {path}"
+                        )
             return destination
         except Exception:
             import shutil

--- a/PhyAgentOS/skill_runtime/installer.py
+++ b/PhyAgentOS/skill_runtime/installer.py
@@ -14,7 +14,12 @@ from pathlib import Path
 import yaml
 
 from PhyAgentOS.config.paths import get_forge_runtime_root, get_skill_bundle_root
-from PhyAgentOS.skill_runtime.archive import ArchiveValidator, sha256_file
+from PhyAgentOS.skill_runtime.archive import (
+    ArchiveError,
+    ArchiveLimits,
+    ArchiveValidator,
+    sha256_file,
+)
 from PhyAgentOS.skill_runtime.locking import SkillOperationBusyError, SkillOperationLock
 from PhyAgentOS.skill_runtime.manifest import NodeLock, SkillManifest, load_manifest
 from PhyAgentOS.skill_runtime.runtime_manifest import normalize_arch, normalize_platform
@@ -25,10 +30,26 @@ class InstallerError(RuntimeError):
     """Raised when an installation cannot be safely committed."""
 
 
+# Forge nodes carry their own runtime tree (for example PyInstaller onedir
+# bundles), so directory archives need room beyond the Skill bundle defaults.
+_NODE_ARCHIVE_LIMITS = ArchiveLimits(
+    max_files=100_000,
+    max_file_size=2 * 1024 * 1024 * 1024,
+    max_total_size=32 * 1024 * 1024 * 1024,
+)
+
+
 def _payload_root(extracted: Path, required: str) -> Path:
     if (extracted / required).is_file():
         return extracted
     raise InstallerError(f"archive root must contain {required}")
+
+
+def _entrypoint_path(lock: NodeLock, install_root: Path) -> Path:
+    """Resolve the executable inside an installed node version directory."""
+    if lock.artifact_type == "directory_tar_gz":
+        return install_root / lock.entrypoint / lock.entrypoint
+    return install_root / lock.entrypoint
 
 
 def _active_skills(store: RuntimeStateStore) -> list[str]:
@@ -171,9 +192,15 @@ class SkillInstaller:
 
 
 class NodeInstaller:
-    """Install SHA-256-pinned ``tar.gz`` assets containing one executable."""
+    """Install SHA-256-pinned node ``tar.gz`` assets.
+
+    ``executable_tar_gz`` archives hold a single root-level executable;
+    ``directory_tar_gz`` archives hold one root directory named after the
+    entrypoint that contains the executable and its runtime tree.
+    """
 
     receipt_name = ".paos-node.json"
+    artifact_types = ("executable_tar_gz", "directory_tar_gz")
 
     def __init__(
         self,
@@ -202,13 +229,17 @@ class NodeInstaller:
         target = versions / lock.artifact_id
         if target.exists():
             if self.satisfies(lock):
-                return target / lock.entrypoint
+                return _entrypoint_path(lock, target)
             raise InstallerError("installed node artifact ID has different contents")
 
         temporary = Path(tempfile.mkdtemp(prefix=".node-install-", dir=versions))
         try:
-            staged = temporary / lock.entrypoint
-            self._extract_executable(archive, staged, lock)
+            if lock.artifact_type == "directory_tar_gz":
+                self._extract_directory(archive, temporary, lock)
+            else:
+                staged = temporary / lock.entrypoint
+                self._extract_executable(archive, staged, lock)
+            staged = _entrypoint_path(lock, temporary)
             staged.chmod(0o755)
             receipt = {
                 "schema_version": 1,
@@ -224,7 +255,7 @@ class NodeInstaller:
                 encoding="utf-8",
             )
             os.replace(temporary, target)
-            return target / lock.entrypoint
+            return _entrypoint_path(lock, target)
         except InstallerError:
             raise
         except Exception as exc:
@@ -234,8 +265,9 @@ class NodeInstaller:
 
     def load(self, lock: NodeLock) -> Path:
         self._verify_lock_host(lock)
-        path = self.root / lock.node_id / "versions" / lock.artifact_id / lock.entrypoint
-        receipt_path = path.parent / self.receipt_name
+        install_root = self.root / lock.node_id / "versions" / lock.artifact_id
+        path = _entrypoint_path(lock, install_root)
+        receipt_path = install_root / self.receipt_name
         if not path.is_file() or path.is_symlink():
             raise InstallerError("installed Forge node executable is missing")
         if path.stat().st_mode & 0o111 == 0:
@@ -274,7 +306,7 @@ class NodeInstaller:
 
     @staticmethod
     def _verify_lock_host(lock: NodeLock) -> None:
-        if lock.artifact_type != "executable_tar_gz":
+        if lock.artifact_type not in NodeInstaller.artifact_types:
             raise InstallerError(f"unsupported Forge node artifact type: {lock.artifact_type}")
         if lock.platform != normalize_platform() or lock.arch != normalize_arch():
             raise InstallerError(
@@ -316,6 +348,42 @@ class NodeInstaller:
             raise
         except (OSError, tarfile.TarError) as exc:
             raise InstallerError(f"invalid Forge node tar.gz archive: {exc}") from exc
+
+    @staticmethod
+    def _extract_directory(archive: Path, staging: Path, lock: NodeLock) -> None:
+        """Extract a ``directory_tar_gz`` tree into ``staging``.
+
+        The archive must contain exactly one root directory named after the
+        lock entrypoint; the executable lives at
+        ``<entrypoint>/<entrypoint>`` inside that tree.
+        """
+        payload = staging / ".payload"
+        validator = ArchiveValidator(_NODE_ARCHIVE_LIMITS, allow_internal_links=True)
+        try:
+            validator.extract(archive, payload, verify_manifest=False)
+        except ArchiveError as exc:
+            raise InstallerError(f"invalid Forge node tar.gz archive: {exc}") from exc
+        root = payload / lock.entrypoint
+        try:
+            entries = [entry.name for entry in payload.iterdir()]
+            if entries != [lock.entrypoint]:
+                raise InstallerError(
+                    "Forge node directory archive must contain exactly one root "
+                    f"directory named after the entrypoint: {', '.join(sorted(entries))}"
+                )
+            if not root.is_dir() or root.is_symlink():
+                raise InstallerError(
+                    "Forge node directory archive root must be a real directory"
+                )
+            executable = root / lock.entrypoint
+            if executable.is_symlink() or not executable.is_file():
+                raise InstallerError(
+                    f"Forge node directory archive must contain executable "
+                    f"'{lock.entrypoint}/{lock.entrypoint}'"
+                )
+            os.replace(root, staging / lock.entrypoint)
+        finally:
+            shutil.rmtree(payload, ignore_errors=True)
 
 
 def _inject_node_environment(

--- a/PhyAgentOS/skill_runtime/manifest.py
+++ b/PhyAgentOS/skill_runtime/manifest.py
@@ -40,6 +40,7 @@ _NODE_LOCK_FIELDS = {
     "entrypoint",
     "sha256",
 }
+_NODE_ARTIFACT_TYPES = {"executable_tar_gz", "directory_tar_gz"}
 
 
 class ManifestError(ValueError):
@@ -146,7 +147,12 @@ class RuntimeProfile:
 
 @dataclass(frozen=True)
 class NodeLock:
-    """Immutable reference to one single-executable ``tar.gz`` release asset."""
+    """Immutable reference to a pinned ``tar.gz`` node release asset.
+
+    ``executable_tar_gz`` archives contain a single root-level executable;
+    ``directory_tar_gz`` archives contain one root directory named after the
+    entrypoint that holds the executable and its runtime tree.
+    """
 
     node_id: str
     artifact_id: str
@@ -171,9 +177,10 @@ class NodeLock:
         artifact_type = _string(
             data.get("artifact_type"), f"{label}.artifact_type"
         ).lower()
-        if artifact_type != "executable_tar_gz":
+        if artifact_type not in _NODE_ARTIFACT_TYPES:
             raise ManifestError(
-                f"{label}.artifact_type must be 'executable_tar_gz'; "
+                f"{label}.artifact_type must be one of "
+                f"{', '.join(sorted(_NODE_ARTIFACT_TYPES))}; "
                 "additional artifact types are reserved for future installers"
             )
         entrypoint = _string(data.get("entrypoint"), f"{label}.entrypoint")

--- a/README.md
+++ b/README.md
@@ -312,7 +312,9 @@ paos forge-node verify <skill-name> <node-id>
 
 Each Forge Skill bundle declares its workflow document, required Tool IDs, named runtime profiles,
 and exact platform/architecture Node locks. Each locked archive has an exact SHA-256 and contains
-one named root-level executable. For Registry Node downloads, the verified Skill lock supplies the
+either one named root-level executable (`executable_tar_gz`) or one root directory named after the
+entrypoint that holds the executable and its runtime tree (`directory_tar_gz`). For Registry Node
+downloads, the verified Skill lock supplies the
 digest when the Registry omits that duplicate field, and the exact size is resolved before the
 download begins; installation records and verifies the extracted binary hash.
 `python scripts/package_skill.py <bundle-dir> --output-dir <directory>` creates a deterministic

--- a/README_zh.md
+++ b/README_zh.md
@@ -305,8 +305,9 @@ paos forge-node verify <skill-name> <node-id>
 ```
 
 每个 Forge Skill Bundle 声明工作流文档、所需 Tool ID、命名 Runtime profile，以及精确的
-平台/架构 Node lock。每个锁定归档具有精确 SHA-256，并且只包含一个指定文件名的根目录
-可执行文件；安装时另行记录并校验解包后的 binary hash。
+平台/架构 Node lock。每个锁定归档具有精确 SHA-256；`executable_tar_gz` 只包含一个指定文件名的
+根目录可执行文件，`directory_tar_gz` 则只包含一个以 entrypoint 命名的根目录（同名可执行文件及
+其运行时树置于其中）。安装时另行记录并校验解包后的 binary hash。
 `python scripts/package_skill.py <bundle-dir> --output-dir <directory>` 可生成确定性发布 Bundle。
 PhyAgentOS 源码与发布包不内置具体 Forge Skill、Forge node、模型或仿真资源；
 部署者只需独立获取实际需要的 Skill 并显式安装。

--- a/docs/en/01-framework-introduction.md
+++ b/docs/en/01-framework-introduction.md
@@ -112,7 +112,7 @@ facts but do not fabricate an Action capture window.
 ## 8. Skill Runtime
 
 Skill Runtime manages installed manifest-v2 bundles and explicit named Dora profiles. Bundles use
-safe archive extraction, SHA-256 inventories, exact single-executable node locks, transactional replacement,
+safe archive extraction, SHA-256 inventories, exact single-entrypoint node locks, transactional replacement,
 persistent state, lifecycle logs, and Gateway `/tools` health checks.
 
 Skill discovery priority is workspace override, installed Skill, then built-in Skill. A healthy

--- a/docs/en/03-developer-manual.md
+++ b/docs/en/03-developer-manual.md
@@ -131,9 +131,13 @@ execution references, bundle metadata, and tombstone information required for au
 A `skill.yaml` manifest must use `manifest_version: 2`, a directory-safe name/version, a relative
 Skill document, an HTTP(S) `gateway_url`, non-empty required Tools, at least one profile, and strict
 known fields. Registry-resolved nodes require artifact identity, version, platform, architecture,
-archive type, one root executable entrypoint, and SHA-256.
+archive type (`executable_tar_gz` or `directory_tar_gz`), the entrypoint, and SHA-256. An
+`executable_tar_gz` archive contains one root-level executable named by the entrypoint; a
+`directory_tar_gz` archive contains one root directory named after the entrypoint that holds the
+same-named executable plus its runtime tree (tree-internal relative symlinks are allowed).
 
-Archive validation rejects absolute/traversing paths, links, duplicate/colliding paths, oversized
+Archive validation rejects absolute/traversing paths, links outside the node-tree cases above,
+duplicate/colliding paths, oversized
 files, expansion-limit violations, missing inventory entries, and digest mismatches. Skill and Node
 installers stage content, validate it, then atomically replace the target with rollback support.
 

--- a/docs/forge/README.md
+++ b/docs/forge/README.md
@@ -177,7 +177,9 @@ never alters Gateway facts, AgentTask terminal state, or verification attempts.
 Skill Runtime installs and manages manifest-v2 Bundles. Installation requires safe contained
 paths, bounded extraction, SHA-256 file inventory, strict manifest validation, staging, atomic
 replacement, and rollback. Each Node lock fixes artifact ID, version, platform, architecture,
-archive type, root executable name, and SHA-256. Static-index downloads carry size and digest.
+archive type (`executable_tar_gz`: one root-level executable; `directory_tar_gz`: one root
+directory named after the entrypoint holding the executable and its runtime tree), the entrypoint,
+and SHA-256. Static-index downloads carry size and digest.
 Registry Node downloads use the verified Skill lock as the digest authority and resolve an exact
 size from Registry metadata or the direct-download endpoint before entering the cache. Installation
 is explicit and confirmed by default.

--- a/docs/forge/README_zh.md
+++ b/docs/forge/README_zh.md
@@ -171,7 +171,8 @@ AgentTask terminal state 或 verification attempt。
 
 Skill Runtime 安装并管理 manifest v2 Bundle。安装要求安全 contained path、有界解包、SHA-256
 文件清单、严格 manifest、staging、原子替换与 rollback。每个 Node lock 固定 artifact ID、版本、
-平台、架构、归档类型、根目录可执行文件名与 SHA-256。静态 index 下载条目包含 size 与 digest；
+平台、架构、归档类型（`executable_tar_gz`：单个根目录 executable；`directory_tar_gz`：仅含一个
+以 entrypoint 命名的根目录，内放可执行文件及其运行时树）、entrypoint 与 SHA-256。静态 index 下载条目包含 size 与 digest；
 Registry Node 下载以已验证的 Skill lock 为摘要权威，并在进入 cache 前从 Registry 元数据或直接
 下载端点解析精确大小。安装始终显式触发，默认还需确认。
 

--- a/docs/forge/UNIFIED_TOOL_API.md
+++ b/docs/forge/UNIFIED_TOOL_API.md
@@ -55,7 +55,8 @@ PlanRevision to the same task; it does not create another execution plane.
 
 `paos skill` discovers and installs manifest-v2 bundles, verifies SHA-256 inventories, and manages
 an explicit named Dora profile. Installation uses safe extraction and atomic replacement. Each Node
-lock fixes platform, architecture, root executable name, and archive SHA-256; the installer also
+lock fixes platform, architecture, archive type (`executable_tar_gz` or `directory_tar_gz`), the
+entrypoint, and archive SHA-256; the installer also
 records the extracted binary hash. Downloads require
 either `resourceRegistry.url`, `PAOS_RESOURCE_REGISTRY_URL`, or an explicit static index.
 

--- a/docs/user_development_guide/COMMUNICATION.md
+++ b/docs/user_development_guide/COMMUNICATION.md
@@ -133,7 +133,7 @@ SQLite update 与 artifact write 在各自边界中保持事务或原子。不�
 ## 11. Skill Runtime 与 Registry 边界
 
 Registry/index client 返回 artifact metadata 与下载。Cache/installer 要求 size 与 SHA-256，
-随后校验 archive inventory 和精确单可执行文件 Node lock，再原子安装。RuntimeManager 启动命名 Dora flow
+随后校验 archive inventory 和 Node 归档契约（单根目录可执行文件，或 `directory_tar_gz` 的单根目录树），再原子安装。RuntimeManager 启动命名 Dora flow
 并观察 Gateway `/tools`，不调用另一套 Gateway Agent API。
 
 活动 Runtime availability provider 向 Agent 提供 Skill visibility 与 Gateway URL，但不修改

--- a/docs/user_development_guide/COMMUNICATION_en.md
+++ b/docs/user_development_guide/COMMUNICATION_en.md
@@ -139,7 +139,8 @@ fail-open.
 ## 11. Skill Runtime and Registry boundary
 
 Registry/index clients return artifact metadata and downloads. Cache and installers require size
-and SHA-256, then validate archive inventories and exact single-executable Node locks before atomic installation.
+and SHA-256, then validate archive inventories and the Node archive contract (single root
+executable, or a single root directory tree for `directory_tar_gz`) before atomic installation.
 RuntimeManager starts a named Dora flow and observes Gateway `/tools`; it never calls an alternate
 Gateway Agent API.
 

--- a/docs/user_development_guide/README.md
+++ b/docs/user_development_guide/README.md
@@ -130,8 +130,10 @@ artifacts:
       sha256: <64-character-sha256>
 ```
 
-所有路径必须相对并包含在 Bundle 内。每个 Node archive 具有 lock 指定的 SHA-256，并且只包含
-一个 lock 指定文件名的根目录 executable；installer 在 receipt 中另行记录解包后 binary hash。
+所有路径必须相对并包含在 Bundle 内。每个 Node archive 具有 lock 指定的 SHA-256。
+`executable_tar_gz` 只包含一个 lock 指定文件名的根目录 executable；`directory_tar_gz`
+只包含一个以 `entrypoint` 命名的根目录，同名 executable 及其运行时树置于其中（仅允许
+解析不出树的相对符号链接）。installer 在 receipt 中另行记录解包后 binary hash。
 Bundle archive inventory 需要覆盖每个文件及 SHA-256；links、路径穿越、冲突、过度展开和未列出
 内容会被拒绝。
 
@@ -173,8 +175,10 @@ rollback。不得要求调用方关闭摘要校验。
 
 ### 5.2 不可变发布顺序
 
-1. 先发布并登记所有 Node artifacts。每个 `executable_tar_gz` 归档根目录只能包含一个与
-   `entrypoint` 同名的 executable，最终归档 SHA-256 必须写入 Skill lock。
+1. 先发布并登记所有 Node artifacts。`executable_tar_gz` 归档根目录只能包含一个与
+   `entrypoint` 同名的 executable；`directory_tar_gz` 归档根目录只能包含一个与
+   `entrypoint` 同名的目录（内含同名 executable 与运行时树）。最终归档 SHA-256 必须写入
+   Skill lock。
 2. 固定 `skill.yaml` 的 name/version、profiles 与 Node locks，执行打包，并保存输出的 Bundle
    SHA-256 与 `size_bytes`。
 3. 将 Bundle 上传到不可覆盖、长期有效的 HTTPS 对象键。上传后从最终 URL 回读并重新校验

--- a/docs/user_development_guide/README_en.md
+++ b/docs/user_development_guide/README_en.md
@@ -133,8 +133,11 @@ artifacts:
       sha256: <64-character-sha256>
 ```
 
-All paths are relative and contained by the Bundle. Each Node archive has the locked SHA-256 and
-contains exactly one root-level executable with the locked filename; the installer records the
+All paths are relative and contained by the Bundle. Each Node archive has the locked SHA-256.
+An `executable_tar_gz` archive contains exactly one root-level executable with the locked
+filename; a `directory_tar_gz` archive contains exactly one root directory named after the
+entrypoint that holds the same-named executable and its runtime tree (tree-internal relative
+symlinks only). The installer records the
 extracted binary hash in its receipt. The Bundle archive inventory must
 cover every file with SHA-256. Links, path traversal, collisions, oversized expansion, and unlisted
 content are rejected.
@@ -181,8 +184,10 @@ verification.
 
 ### 5.2 Immutable publication order
 
-1. Publish and register every Node artifact first. Each `executable_tar_gz` archive contains only
-   one root-level executable named by `entrypoint`; put the final archive SHA-256 in the Skill lock.
+1. Publish and register every Node artifact first. An `executable_tar_gz` archive contains only
+   one root-level executable named by `entrypoint`; a `directory_tar_gz` archive contains only one
+   root directory named by `entrypoint` (holding the same-named executable and its runtime tree).
+   Put the final archive SHA-256 in the Skill lock.
 2. Freeze the `skill.yaml` name/version, profiles, and Node locks, package the Bundle, and retain the
    printed Bundle SHA-256 and `size_bytes`.
 3. Upload the Bundle to a non-overwritable, long-lived HTTPS object key. Read it back from the final

--- a/docs/zh/01-framework-introduction.md
+++ b/docs/zh/01-framework-introduction.md
@@ -106,7 +106,7 @@ Forge ToolResult 与事件仍是权威执行事实。
 ## 8. Skill Runtime
 
 Skill Runtime 管理 manifest v2 Bundle 和显式命名 Dora profile。Bundle 使用安全解包、
-SHA-256 清单、精确单可执行文件 Node lock、事务替换、持久化状态、生命周期日志以及 Gateway `/tools`
+SHA-256 清单、精确单 entrypoint Node lock、事务替换、持久化状态、生命周期日志以及 Gateway `/tools`
 健康检查。
 
 Skill 发现优先级为 workspace override、已安装 Skill、内置 Skill。健康活动 Runtime 会把

--- a/docs/zh/03-developer-manual.md
+++ b/docs/zh/03-developer-manual.md
@@ -127,9 +127,12 @@ metadata 和审计所需 tombstone。
 `skill.yaml` 必须使用 `manifest_version: 2`，包含目录安全的 name/version、相对 Skill
 document、HTTP(S) `gateway_url`、非空 required Tools、至少一个 profile，并拒绝未知字段。
 Registry resolver 的 Node 必须包含 artifact identity、version、platform、architecture、
-archive type、单一根目录 executable entrypoint 与 SHA-256。
+archive type（`executable_tar_gz` 或 `directory_tar_gz`）、entrypoint 与 SHA-256。
+`executable_tar_gz` 归档只含一个由 entrypoint 命名的根目录 executable；`directory_tar_gz`
+归档只含一个以 entrypoint 命名的根目录，内放同名 executable 及其运行时树（允许树内相对
+符号链接）。
 
-归档校验拒绝绝对/穿越路径、links、重复或冲突路径、超大文件、展开限制违规、清单缺项与摘要
+归档校验拒绝绝对/穿越路径、links（上述节点树内相对链接除外）、重复或冲突路径、超大文件、展开限制违规、清单缺项与摘要
 不一致。Skill/Node installer 先 staging 与校验，再原子替换目标，并支持 rollback。
 
 RuntimeManager：

--- a/tests/test_node_installer_directory.py
+++ b/tests/test_node_installer_directory.py
@@ -1,0 +1,400 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+import tarfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from PhyAgentOS.skill_runtime.catalog import SkillCatalog
+from PhyAgentOS.skill_runtime.installer import (
+    InstallerError,
+    NodeInstaller,
+    SkillEnvironmentBuilder,
+)
+from PhyAgentOS.skill_runtime.manifest import ManifestError, NodeLock, load_manifest
+from PhyAgentOS.skill_runtime.runtime_manifest import normalize_arch, normalize_platform
+from PhyAgentOS.skill_runtime.state import RuntimeStateStore
+
+
+def _file_member(archive: tarfile.TarFile, name: str, data: bytes, *, mode: int = 0o755) -> None:
+    info = tarfile.TarInfo(name)
+    info.size = len(data)
+    info.mode = mode
+    archive.addfile(info, io.BytesIO(data))
+
+
+def _dir_member(archive: tarfile.TarFile, name: str) -> None:
+    info = tarfile.TarInfo(name)
+    info.type = tarfile.DIRTYPE
+    info.mode = 0o755
+    archive.addfile(info)
+
+
+def _link_member(
+    archive: tarfile.TarFile, name: str, target: str, *, hard: bool = False
+) -> None:
+    info = tarfile.TarInfo(name)
+    if hard:
+        info.type = tarfile.LNKTYPE
+        info.linkname = target
+    else:
+        info.type = tarfile.SYMTYPE
+        info.linkname = target
+    info.mode = 0o777
+    archive.addfile(info)
+
+
+def _directory_archive(path: Path) -> str:
+    """A minimal well-formed onedir archive: lerobot_infer/lerobot_infer + lib tree."""
+    with tarfile.open(path, "w:gz") as archive:
+        _dir_member(archive, "lerobot_infer")
+        _dir_member(archive, "lerobot_infer/_internal")
+        _dir_member(archive, "lerobot_infer/_internal/libs")
+        _file_member(archive, "lerobot_infer/lerobot_infer", b"#!/bin/sh\nexit 0\n")
+        _file_member(
+            archive, "lerobot_infer/_internal/libs/libdemo.so", b"lib-bytes", mode=0o644
+        )
+        _link_member(archive, "lerobot_infer/_internal/libdemo.so", "libs/libdemo.so")
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _lock(sha256: str, *, artifact_type: str = "directory_tar_gz") -> NodeLock:
+    return NodeLock.from_dict(
+        "lerobot_inference",
+        {
+            "artifact_id": "lerobot_inference-1.0.5-linux-x86_64",
+            "version": "1.0.5",
+            "platform": normalize_platform(),
+            "arch": normalize_arch(),
+            "artifact_type": artifact_type,
+            "entrypoint": "lerobot_infer",
+            "sha256": sha256,
+        },
+    )
+
+
+def _installer(tmp_path: Path) -> NodeInstaller:
+    return NodeInstaller(
+        tmp_path / "runtime", state_store=RuntimeStateStore(tmp_path / "states")
+    )
+
+
+def _version_dir(installer: NodeInstaller, lock: NodeLock) -> Path:
+    return installer.root / lock.node_id / "versions" / lock.artifact_id
+
+
+# ---------------------------------------------------------------------------
+# executable_tar_gz regression
+# ---------------------------------------------------------------------------
+
+
+def test_executable_archive_still_installs_at_version_root(tmp_path: Path) -> None:
+    archive_path = tmp_path / "node.tar.gz"
+    with tarfile.open(archive_path, "w:gz") as archive:
+        _file_member(archive, "lerobot_infer", b"single-binary")
+    lock = _lock(
+        hashlib.sha256(archive_path.read_bytes()).hexdigest(),
+        artifact_type="executable_tar_gz",
+    )
+    installer = _installer(tmp_path)
+
+    installed = installer.install(archive_path, lock)
+
+    assert installed == _version_dir(installer, lock) / "lerobot_infer"
+    assert installed.read_bytes() == b"single-binary"
+    assert installer.load(lock) == installed
+    assert installer.satisfies(lock)
+    assert (_version_dir(installer, lock) / ".paos-node.json").is_file()
+
+
+# ---------------------------------------------------------------------------
+# directory_tar_gz happy path
+# ---------------------------------------------------------------------------
+
+
+def test_directory_archive_installs_tree_and_returns_nested_entrypoint(
+    tmp_path: Path,
+) -> None:
+    archive_path = tmp_path / "node.tar.gz"
+    lock = _lock(_directory_archive(archive_path))
+    installer = _installer(tmp_path)
+
+    installed = installer.install(archive_path, lock)
+
+    entrypoint = _version_dir(installer, lock) / "lerobot_infer" / "lerobot_infer"
+    assert installed == entrypoint
+    assert entrypoint.is_file()
+    assert os.access(entrypoint, os.X_OK)
+    link = _version_dir(installer, lock) / "lerobot_infer/_internal/libdemo.so"
+    assert link.is_symlink()
+    assert link.resolve().name == "libdemo.so"
+    assert (_version_dir(installer, lock) / ".paos-node.json").is_file()
+    assert not (_version_dir(installer, lock) / ".payload").exists()
+    assert installer.satisfies(lock)
+    assert installer.load(lock) == entrypoint
+
+
+def test_directory_install_is_idempotent(tmp_path: Path) -> None:
+    archive_path = tmp_path / "node.tar.gz"
+    lock = _lock(_directory_archive(archive_path))
+    installer = _installer(tmp_path)
+
+    first = installer.install(archive_path, lock)
+    second = installer.install(archive_path, lock)
+
+    assert first == second
+
+
+def test_directory_receipt_pins_nested_binary_sha256(tmp_path: Path) -> None:
+    archive_path = tmp_path / "node.tar.gz"
+    lock = _lock(_directory_archive(archive_path))
+    installer = _installer(tmp_path)
+
+    installer.install(archive_path, lock)
+
+    receipt_text = (_version_dir(installer, lock) / ".paos-node.json").read_text(
+        encoding="utf-8"
+    )
+    receipt = yaml.safe_load(receipt_text)
+    assert receipt["binary_sha256"] == hashlib.sha256(b"#!/bin/sh\nexit 0\n").hexdigest()
+    # Tampering with the executable must fail the load-time verification.
+    entrypoint = _version_dir(installer, lock) / "lerobot_infer" / "lerobot_infer"
+    entrypoint.write_bytes(b"tampered")
+    assert not installer.satisfies(lock)
+
+
+# ---------------------------------------------------------------------------
+# directory_tar_gz rejections
+# ---------------------------------------------------------------------------
+
+
+def _rejects(tmp_path: Path, lock: NodeLock, *, match: str, build) -> None:
+    archive_path = tmp_path / "node.tar.gz"
+    build(archive_path)
+    broken = _lock("0" * 64)
+    object.__setattr__(broken, "sha256", hashlib.sha256(archive_path.read_bytes()).hexdigest())
+    # Rebuild the lock with the real digest of the crafted archive.
+    real = _lock(hashlib.sha256(archive_path.read_bytes()).hexdigest())
+    object.__setattr__(real, "artifact_type", lock.artifact_type)
+    object.__setattr__(real, "entrypoint", lock.entrypoint)
+    with pytest.raises(InstallerError, match=match):
+        _installer(tmp_path).install(archive_path, real)
+
+
+def test_directory_archive_rejects_wrong_root_name(tmp_path: Path) -> None:
+    def build(path: Path) -> None:
+        with tarfile.open(path, "w:gz") as archive:
+            _dir_member(archive, "wrong_name")
+            _file_member(archive, "wrong_name/lerobot_infer", b"#!/bin/sh\nexit 0\n")
+
+    _rejects(tmp_path, _lock("0" * 64), match="one root", build=build)
+
+
+def test_directory_archive_rejects_multiple_root_entries(tmp_path: Path) -> None:
+    def build(path: Path) -> None:
+        with tarfile.open(path, "w:gz") as archive:
+            _dir_member(archive, "lerobot_infer")
+            _file_member(archive, "lerobot_infer/lerobot_infer", b"#!/bin/sh\nexit 0\n")
+            _file_member(archive, "extra", b"stray", mode=0o644)
+
+    _rejects(tmp_path, _lock("0" * 64), match="one root", build=build)
+
+
+def test_directory_archive_rejects_missing_nested_entrypoint(tmp_path: Path) -> None:
+    def build(path: Path) -> None:
+        with tarfile.open(path, "w:gz") as archive:
+            _dir_member(archive, "lerobot_infer")
+            _file_member(
+                archive, "lerobot_infer/_internal/data", b"data", mode=0o644
+            )
+
+    _rejects(tmp_path, _lock("0" * 64), match="must contain executable", build=build)
+
+
+def test_directory_archive_rejects_symlinked_entrypoint(tmp_path: Path) -> None:
+    def build(path: Path) -> None:
+        with tarfile.open(path, "w:gz") as archive:
+            _dir_member(archive, "lerobot_infer")
+            _file_member(
+                archive, "lerobot_infer/_internal/real", b"#!/bin/sh\nexit 0\n"
+            )
+            _link_member(archive, "lerobot_infer/lerobot_infer", "_internal/real")
+
+    _rejects(tmp_path, _lock("0" * 64), match="must contain executable", build=build)
+
+
+def test_directory_archive_rejects_escaping_symlink(tmp_path: Path) -> None:
+    def build(path: Path) -> None:
+        with tarfile.open(path, "w:gz") as archive:
+            _dir_member(archive, "lerobot_infer")
+            _file_member(archive, "lerobot_infer/lerobot_infer", b"#!/bin/sh\nexit 0\n")
+            _link_member(archive, "lerobot_infer/_internal/escape", "../../outside")
+
+    _rejects(tmp_path, _lock("0" * 64), match="inside the archive", build=build)
+
+
+def test_directory_archive_rejects_absolute_symlink(tmp_path: Path) -> None:
+    def build(path: Path) -> None:
+        with tarfile.open(path, "w:gz") as archive:
+            _dir_member(archive, "lerobot_infer")
+            _file_member(archive, "lerobot_infer/lerobot_infer", b"#!/bin/sh\nexit 0\n")
+            _link_member(archive, "lerobot_infer/_internal/abs", "/etc/passwd")
+
+    _rejects(tmp_path, _lock("0" * 64), match="relative", build=build)
+
+
+def test_directory_archive_rejects_dangling_symlink(tmp_path: Path) -> None:
+    def build(path: Path) -> None:
+        with tarfile.open(path, "w:gz") as archive:
+            _dir_member(archive, "lerobot_infer")
+            _file_member(archive, "lerobot_infer/lerobot_infer", b"#!/bin/sh\nexit 0\n")
+            _link_member(archive, "lerobot_infer/_internal/dangling", "missing.so")
+
+    _rejects(tmp_path, _lock("0" * 64), match="dangling or cyclic", build=build)
+
+
+def test_directory_archive_rejects_cyclic_symlinks(tmp_path: Path) -> None:
+    def build(path: Path) -> None:
+        with tarfile.open(path, "w:gz") as archive:
+            _dir_member(archive, "lerobot_infer")
+            _file_member(archive, "lerobot_infer/lerobot_infer", b"#!/bin/sh\nexit 0\n")
+            _link_member(archive, "lerobot_infer/_internal/a", "b")
+            _link_member(archive, "lerobot_infer/_internal/b", "a")
+
+    _rejects(tmp_path, _lock("0" * 64), match="dangling or cyclic", build=build)
+
+
+def test_directory_archive_rejects_hard_links(tmp_path: Path) -> None:
+    def build(path: Path) -> None:
+        with tarfile.open(path, "w:gz") as archive:
+            _dir_member(archive, "lerobot_infer")
+            _file_member(archive, "lerobot_infer/lerobot_infer", b"#!/bin/sh\nexit 0\n")
+            _file_member(
+                archive, "lerobot_infer/_internal/real", b"real", mode=0o644
+            )
+            _link_member(archive, "lerobot_infer/_internal/hard", "_internal/real", hard=True)
+
+    _rejects(tmp_path, _lock("0" * 64), match="hard links are forbidden", build=build)
+
+
+def test_directory_archive_rejects_sha256_mismatch(tmp_path: Path) -> None:
+    archive_path = tmp_path / "node.tar.gz"
+    _directory_archive(archive_path)
+    lock = _lock("f" * 64)
+
+    with pytest.raises(InstallerError, match="sha256 does not match"):
+        _installer(tmp_path).install(archive_path, lock)
+
+
+# ---------------------------------------------------------------------------
+# manifest parsing
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_accepts_directory_tar_gz_locks() -> None:
+    lock = _lock("a" * 64)
+
+    assert lock.artifact_type == "directory_tar_gz"
+
+
+def test_manifest_still_rejects_unknown_artifact_types() -> None:
+    with pytest.raises(ManifestError, match="reserved for future installers"):
+        NodeLock.from_dict(
+            "gateway",
+            {
+                "artifact_id": "gateway-one",
+                "version": "1.0.0",
+                "platform": normalize_platform(),
+                "arch": normalize_arch(),
+                "artifact_type": "archive",
+                "entrypoint": "gateway",
+                "sha256": "0" * 64,
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# SkillEnvironmentBuilder integration
+# ---------------------------------------------------------------------------
+
+
+def _installed_skill_with_directory_node(tmp_path: Path) -> tuple[Path, NodeLock]:
+    archive_path = tmp_path / "node.tar.gz"
+    lock = _lock(_directory_archive(archive_path))
+    _installer(tmp_path).install(archive_path, lock)
+
+    bundle = tmp_path / "skills" / "demo"
+    (bundle / "profiles" / "local").mkdir(parents=True)
+    (bundle / "SKILL.md").write_text("# Demo\n", encoding="utf-8")
+    manifest = {
+        "manifest_version": 2,
+        "name": "demo",
+        "version": "1.0.0",
+        "description": "Directory node integration",
+        "skill_document": "SKILL.md",
+        "gateway_url": "http://127.0.0.1:19002",
+        "required_tools": ["demo.run"],
+        "profiles": {
+            "local": {
+                "dataflow": "profiles/local/dataflow.yaml",
+                "required_binaries": ["lerobot_infer"],
+            }
+        },
+        "artifacts": {
+            "resolver": "local",
+            "nodes": {"lerobot_inference": yaml.safe_load(yaml.safe_dump(
+                {
+                    "artifact_id": lock.artifact_id,
+                    "version": lock.version,
+                    "platform": lock.platform,
+                    "arch": lock.arch,
+                    "artifact_type": lock.artifact_type,
+                    "entrypoint": lock.entrypoint,
+                    "sha256": lock.sha256,
+                }
+            ))},
+        },
+    }
+    (bundle / "skill.yaml").write_text(
+        yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8"
+    )
+    (bundle / "profiles" / "local" / "dataflow.yaml").write_text(
+        "nodes: []\n", encoding="utf-8"
+    )
+    return bundle, lock
+
+
+def test_environment_builder_links_directory_entrypoint_into_bin(tmp_path: Path) -> None:
+    bundle, lock = _installed_skill_with_directory_node(tmp_path)
+    skill = load_manifest(bundle / "skill.yaml")
+    runtime_root = tmp_path / "runtime"
+    builder = SkillEnvironmentBuilder(
+        runtime_root, state_store=RuntimeStateStore(tmp_path / "states")
+    )
+
+    binary_root = builder.prepare(skill, "local")
+
+    link = binary_root / "lerobot_infer"
+    assert link.is_symlink()
+    assert link.resolve() == (
+        runtime_root
+        / "nodes"
+        / lock.node_id
+        / "versions"
+        / lock.artifact_id
+        / "lerobot_infer"
+        / "lerobot_infer"
+    )
+    assert os.access(link, os.X_OK)
+
+
+def test_catalog_loads_skill_with_directory_lock(tmp_path: Path) -> None:
+    bundle, _lock = _installed_skill_with_directory_node(tmp_path)
+
+    skill = SkillCatalog(tmp_path / "skills").get("demo")
+
+    assert skill.artifacts.nodes["lerobot_inference"].artifact_type == "directory_tar_gz"


### PR DESCRIPTION
## Motivation

The current node contract only accepts `executable_tar_gz` archives (exactly
one root-level executable named after the lock entrypoint). PyInstaller
**onedir** bundles — which ship an executable plus its `_internal/` runtime
tree — cannot satisfy that contract, and repacking them as onefile has real
runtime drawbacks (self-extraction at every startup, slower cold start,
Triton JIT / Python-header path issues).

This PR adds a second explicit node artifact type, `directory_tar_gz`, so
publisher-side onedir archives install as-is.

## Contract

`skill.yaml` node lock:

```yaml
artifact_type: directory_tar_gz
entrypoint: lerobot_infer          # still a bare command name
sha256: <archive sha256>           # whole-archive digest, unchanged
```

Archive shape: the root must be **exactly one directory** named after the
entrypoint, containing the same-named executable (`<entrypoint>/<entrypoint>`)
plus its runtime tree. Symbolic links are allowed only when relative and
resolving inside the archive (no absolute, escaping, dangling, or cyclic
links); hard links remain forbidden.

Install layout keeps the existing scheme, with the receipt still at the
version-directory root:

```
nodes/<node_id>/versions/<artifact_id>/<entrypoint>/<entrypoint>
nodes/<node_id>/versions/<artifact_id>/.paos-node.json
```

Because `entrypoint` stays a bare command name and `NodeInstaller.load()`
still returns the executable path, `SkillEnvironmentBuilder` symlinks
(`bin/<entrypoint>`) and dataflow `${FORGE_RUNTIME_BIN}/<entrypoint>`
references work unchanged.

## Changes

- `manifest.py`: `NodeLock` accepts `directory_tar_gz`; unknown artifact
  types are still rejected as "reserved for future installers".
- `archive.py`: `ArchiveValidator(..., allow_internal_links=True)` opts into
  tree-internal relative symlinks with escape/dangling/cycle checks; the
  default (Skill bundle) path is unchanged. Also fixes payload files named
  `archive-manifest.json` being skipped even when `verify_manifest=False`.
- `installer.py`: node-specific `ArchiveLimits` (100k files / 2 GiB per file
  / 32 GiB total — defaults would reject real onedir trees), a shared
  `_entrypoint_path()` resolver, and `_extract_directory()` reusing
  `ArchiveValidator`; `executable_tar_gz` behavior, receipt contents, and
  install layout are byte-for-byte unchanged.
- `cli/commands.py`: `forge-node install` help text no longer says
  "single-executable".
- Docs: every node-contract mention (README, forge README, developer manual,
  framework introduction, unified Tool API reference, and the user
  development guide packaging/publishing sections, EN + ZH) now describes
  both artifact types.

## Testing

- New `tests/test_node_installer_directory.py` (18 cases): single-file
  regression, directory install/load/satisfies/idempotency, receipt pins the
  nested binary digest, and rejections (wrong root name, multiple roots,
  missing/symlinked nested entrypoint, escaping/absolute/dangling/cyclic
  symlinks, hard links, sha256 mismatch, unknown artifact type), manifest
  parsing, and a `SkillEnvironmentBuilder` `bin/` symlink integration test.
- Full suite: 46 passed; `ruff check` clean.
- Verified end-to-end against a real published onedir archive
  (`lerobot_inference-1.0.5`, 5.8 GiB tree, 18,344 members, 97 internal
  symlinks): `install` + `load` + `satisfies` pass, and the entrypoint runs
  `--version` / `--help` successfully both directly and through the
  environment `bin/` symlink.