### PR TITLE
feat(skill-runtime): support digest node bundles

### DIFF
--- a/PhyAgentOS/cli/commands.py
+++ b/PhyAgentOS/cli/commands.py
@@ -1019,16 +1019,27 @@ def _install_skill_bundle(
                                 lock.artifact_id,
                                 expected_sha256=lock.sha256,
                             )
-                            if node_artifact.sha256 != lock.sha256:
-                                raise RuntimeError(
-                                    f"Registry digest for Node {node_id!r} does not match "
-                                    "Skill lock"
-                                )
+                            if lock.sha256 is not None:
+                                if node_artifact.sha256 != lock.sha256:
+                                    raise RuntimeError(
+                                        f"Registry digest for Node {node_id!r} does not match "
+                                        "Skill lock"
+                                    )
+                            elif lock.digest is not None:
+                                if node_artifact.node_digest != lock.digest:
+                                    raise RuntimeError(
+                                        f"Registry node digest for Node {node_id!r} does not "
+                                        "match Skill lock"
+                                    )
                             node_archive = cache.download(node_artifact)
-                            installed = node_installer.install(node_archive, lock)
+                            installed = node_installer.install(
+                                node_archive,
+                                lock,
+                                expected_archive_sha256=node_artifact.sha256,
+                            )
                             if not node_installer.satisfies(lock):
                                 raise RuntimeError(
-                                    f"Node executable {installed!s} does not satisfy Skill lock"
+                                    f"Node artifact {installed!s} does not satisfy Skill lock"
                                 )
                     missing_nodes = []
                 try:
@@ -1433,7 +1444,7 @@ def forge_node_install(
         help="Independently obtained local Node .tar.gz instead of a Registry download",
     ),
 ):
-    """Download the exact single-executable archive pinned by a Skill lock."""
+    """Download the exact Node artifact (archive or bundle) pinned by a Skill lock."""
     from PhyAgentOS.skill_runtime.catalog import SkillCatalog
     from PhyAgentOS.skill_runtime.installer import NodeInstaller
     from PhyAgentOS.skill_runtime.registry import DownloadCache, RegistryClient
@@ -1445,20 +1456,33 @@ def forge_node_install(
             lock = manifest.artifacts.nodes.get(node_id)
             if lock is None:
                 raise RuntimeError(f"Skill {skill_name!r} does not lock Node {node_id!r}")
+            artifact = None
             if archive is None:
                 with RegistryClient() as registry:
                     artifact = registry.node(
                         lock.artifact_id,
                         expected_sha256=lock.sha256,
                     )
-                if artifact.sha256 != lock.sha256:
-                    raise RuntimeError("Registry Node sha256 does not match the Skill lock")
+                if lock.sha256 is not None:
+                    if artifact.sha256 != lock.sha256:
+                        raise RuntimeError(
+                            "Registry Node sha256 does not match the Skill lock"
+                        )
+                elif lock.digest is not None:
+                    if artifact.node_digest != lock.digest:
+                        raise RuntimeError(
+                            "Registry Node digest does not match the Skill lock"
+                        )
                 node_archive = cache.download(artifact)
             else:
                 node_archive = archive.expanduser().resolve()
                 if not node_archive.is_file() or node_archive.is_symlink():
                     raise RuntimeError("local Node archive is not a regular file")
-            installed = NodeInstaller().install(node_archive, lock)
+            installed = NodeInstaller().install(
+                node_archive,
+                lock,
+                expected_archive_sha256=artifact.sha256 if artifact else None,
+            )
         except Exception as error:
             _skill_runtime_error(error)
             return
@@ -1475,7 +1499,7 @@ def forge_node_verify(
     skill_name: str = typer.Argument(..., help="Installed Skill containing the Node lock"),
     node_id: str = typer.Argument(..., help="Node ID from the Skill lock"),
 ):
-    """Verify an installed executable and receipt against its Skill lock."""
+    """Verify an installed Node artifact against its Skill lock."""
     from PhyAgentOS.skill_runtime.catalog import SkillCatalog
     from PhyAgentOS.skill_runtime.installer import NodeInstaller
 
@@ -1490,7 +1514,7 @@ def forge_node_verify(
         return
     console.print(
         f"[green]✓[/green] Forge node [cyan]{lock.node_id}[/cyan] "
-        f"{lock.artifact_id} SHA-256 verified"
+        f"{lock.artifact_id} verified against Skill lock"
     )
 
 # ============================================================================

--- a/PhyAgentOS/skill_runtime/installer.py
+++ b/PhyAgentOS/skill_runtime/installer.py
@@ -17,6 +17,11 @@ from PhyAgentOS.config.paths import get_forge_runtime_root, get_skill_bundle_roo
 from PhyAgentOS.skill_runtime.archive import ArchiveValidator, sha256_file
 from PhyAgentOS.skill_runtime.locking import SkillOperationBusyError, SkillOperationLock
 from PhyAgentOS.skill_runtime.manifest import NodeLock, SkillManifest, load_manifest
+from PhyAgentOS.skill_runtime.node_manifest import (
+    NodeManifest,
+    NodeManifestError,
+    load_node_manifest,
+)
 from PhyAgentOS.skill_runtime.runtime_manifest import normalize_arch, normalize_platform
 from PhyAgentOS.skill_runtime.state import RuntimeStateStore
 
@@ -171,7 +176,12 @@ class SkillInstaller:
 
 
 class NodeInstaller:
-    """Install SHA-256-pinned ``tar.gz`` assets containing one executable."""
+    """Install SHA-256-pinned Forge node artifacts.
+
+    Single-executable ``tar.gz`` archives keep the legacy receipt layout. A
+    digest-locked multi-file bundle is verified against its embedded
+    ``node-manifest.json`` and installed as an immutable directory.
+    """
 
     receipt_name = ".paos-node.json"
 
@@ -185,7 +195,13 @@ class NodeInstaller:
         self.root = runtime_root / "nodes"
         self.state_store = state_store or RuntimeStateStore()
 
-    def install(self, archive: Path, lock: NodeLock) -> Path:
+    def install(
+        self,
+        archive: Path,
+        lock: NodeLock,
+        *,
+        expected_archive_sha256: str | None = None,
+    ) -> Path:
         active = _active_skills(self.state_store)
         if active:
             raise InstallerError(
@@ -194,6 +210,8 @@ class NodeInstaller:
         self._verify_lock_host(lock)
         if not archive.is_file() or archive.is_symlink():
             raise InstallerError("downloaded Forge node archive is not a regular file")
+        if lock.is_bundle:
+            return self._install_bundle(archive, lock, expected_archive_sha256)
         if sha256_file(archive) != lock.sha256:
             raise InstallerError("downloaded Forge node archive sha256 does not match Skill lock")
 
@@ -232,8 +250,66 @@ class NodeInstaller:
         finally:
             shutil.rmtree(temporary, ignore_errors=True)
 
+    def _install_bundle(
+        self,
+        archive: Path,
+        lock: NodeLock,
+        expected_archive_sha256: str | None,
+    ) -> Path:
+        if expected_archive_sha256 is not None:
+            if sha256_file(archive) != expected_archive_sha256.lower():
+                raise InstallerError(
+                    "downloaded Forge node archive sha256 does not match registry metadata"
+                )
+        versions = self.root / lock.node_id / "versions"
+        versions.mkdir(parents=True, exist_ok=True)
+        target = versions / lock.artifact_id
+        if target.exists():
+            if self.satisfies(lock):
+                return target
+            raise InstallerError("installed node artifact ID has different contents")
+        temporary = Path(tempfile.mkdtemp(prefix=".node-install-", dir=versions))
+        try:
+            staged = temporary / lock.artifact_id
+            ArchiveValidator().extract(archive, staged, verify_manifest=False)
+            self._verify_bundle_payload(staged, lock)
+            os.replace(staged, target)
+            return target
+        except InstallerError:
+            raise
+        except Exception as exc:
+            raise InstallerError(f"Forge node bundle installation failed: {exc}") from exc
+        finally:
+            shutil.rmtree(temporary, ignore_errors=True)
+
+    @staticmethod
+    def _verify_bundle_payload(root: Path, lock: NodeLock) -> NodeManifest:
+        try:
+            manifest = load_node_manifest(root / "node-manifest.json", verify_files=True)
+        except NodeManifestError as exc:
+            raise InstallerError(str(exc)) from exc
+        if manifest.node_id != lock.node_id:
+            raise InstallerError("installed node manifest node_id does not match Skill lock")
+        if manifest.artifact_id != lock.artifact_id:
+            raise InstallerError("installed node manifest artifact_id does not match Skill lock")
+        if manifest.version != lock.version:
+            raise InstallerError("installed node manifest version does not match Skill lock")
+        if manifest.digest != lock.digest:
+            raise InstallerError("installed node manifest digest does not match Skill lock")
+        try:
+            manifest.verify_host()
+        except NodeManifestError as exc:
+            raise InstallerError(str(exc)) from exc
+        return manifest
+
     def load(self, lock: NodeLock) -> Path:
         self._verify_lock_host(lock)
+        if lock.is_bundle:
+            root = self.root / lock.node_id / "versions" / lock.artifact_id
+            if not root.is_dir() or root.is_symlink():
+                raise InstallerError("installed Forge node bundle is missing")
+            self._verify_bundle_payload(root, lock)
+            return root
         path = self.root / lock.node_id / "versions" / lock.artifact_id / lock.entrypoint
         receipt_path = path.parent / self.receipt_name
         if not path.is_file() or path.is_symlink():
@@ -265,6 +341,22 @@ class NodeInstaller:
             raise InstallerError("installed Forge node executable sha256 does not match receipt")
         return path
 
+    def load_entrypoints(self, lock: NodeLock) -> dict[str, Path]:
+        """Return ``name -> executable`` for every entrypoint a lock provides."""
+        if not lock.is_bundle:
+            entrypoint = lock.entrypoint
+            if entrypoint is None:
+                raise InstallerError("installed Forge node lock is missing an entrypoint")
+            return {entrypoint: self.load(lock)}
+        root = self.load(lock)
+        try:
+            manifest = load_node_manifest(
+                root / "node-manifest.json", verify_files=False
+            )
+        except NodeManifestError as exc:
+            raise InstallerError(str(exc)) from exc
+        return {name: root / path for name, path in manifest.entrypoints.items()}
+
     def satisfies(self, lock: NodeLock) -> bool:
         try:
             self.load(lock)
@@ -274,7 +366,7 @@ class NodeInstaller:
 
     @staticmethod
     def _verify_lock_host(lock: NodeLock) -> None:
-        if lock.artifact_type != "executable_tar_gz":
+        if not lock.is_bundle and lock.artifact_type != "executable_tar_gz":
             raise InstallerError(f"unsupported Forge node artifact type: {lock.artifact_type}")
         if lock.platform != normalize_platform() or lock.arch != normalize_arch():
             raise InstallerError(
@@ -368,10 +460,10 @@ class SkillEnvironmentBuilder:
             raise InstallerError(f"unknown Skill profile: {profile_name}")
         providers: dict[str, tuple[NodeLock, Path]] = {}
         for _, lock in sorted(skill.artifacts.nodes.items()):
-            binary = self.nodes.load(lock)
-            if lock.entrypoint in providers:
-                raise InstallerError(f"duplicate Forge node entrypoint: {lock.entrypoint}")
-            providers[lock.entrypoint] = (lock, binary)
+            for name, binary in self.nodes.load_entrypoints(lock).items():
+                if name in providers:
+                    raise InstallerError(f"duplicate Forge node entrypoint: {name}")
+                providers[name] = (lock, binary)
         required = {path.as_posix() for path in profile.required_binaries}
         missing = sorted(required - providers.keys())
         if missing:
@@ -385,12 +477,7 @@ class SkillEnvironmentBuilder:
             "skill_version": skill.version,
             "profile": profile_name,
             "nodes": {
-                lock.node_id: {
-                    "artifact_id": lock.artifact_id,
-                    "artifact_type": lock.artifact_type,
-                    "entrypoint": lock.entrypoint,
-                    "sha256": lock.sha256,
-                }
+                lock.node_id: self._lock_value(lock)
                 for lock, _ in providers.values()
             },
             "entrypoints": sorted(required),
@@ -464,6 +551,17 @@ class SkillEnvironmentBuilder:
                 shutil.rmtree(temporary, ignore_errors=True)
         self._replace_symlink(profile_root / "current", target)
         return target / "bin"
+
+    @staticmethod
+    def _lock_value(lock: NodeLock) -> dict[str, object]:
+        value: dict[str, object] = {"artifact_id": lock.artifact_id}
+        if lock.is_bundle:
+            value["digest"] = lock.digest
+        else:
+            value["artifact_type"] = lock.artifact_type
+            value["entrypoint"] = lock.entrypoint
+            value["sha256"] = lock.sha256
+        return value
 
     @staticmethod
     def _replace_symlink(link: Path, target: Path) -> None:

--- a/PhyAgentOS/skill_runtime/manifest.py
+++ b/PhyAgentOS/skill_runtime/manifest.py
@@ -39,6 +39,7 @@ _NODE_LOCK_FIELDS = {
     "artifact_type",
     "entrypoint",
     "sha256",
+    "digest",
 }
 
 
@@ -146,16 +147,29 @@ class RuntimeProfile:
 
 @dataclass(frozen=True)
 class NodeLock:
-    """Immutable reference to one single-executable ``tar.gz`` release asset."""
+    """Immutable reference to one Forge node artifact.
+
+    Two lock forms are supported:
+
+    * ``executable_tar_gz`` — a single-executable archive pinned by ``sha256``.
+    * ``node_bundle`` — a multi-file node bundle pinned by the digest of its
+      embedded ``node-manifest.json``; entrypoints come from that manifest.
+    """
 
     node_id: str
     artifact_id: str
     version: str
     platform: str
     arch: str
-    artifact_type: str
-    entrypoint: str
-    sha256: str
+    artifact_type: str | None = None
+    entrypoint: str | None = None
+    sha256: str | None = None
+    digest: str | None = None
+
+    @property
+    def is_bundle(self) -> bool:
+        """True when this lock pins a multi-file node bundle by digest."""
+        return self.digest is not None
 
     @classmethod
     def from_dict(cls, node_id: str, value: Any) -> NodeLock:
@@ -168,6 +182,26 @@ class NodeLock:
         artifact_id = _string(data.get("artifact_id"), f"{label}.artifact_id")
         if artifact_id in {".", ".."} or "/" in artifact_id or "\\" in artifact_id:
             raise ManifestError(f"{label}.artifact_id must be directory-safe")
+        common = {
+            "node_id": safe_node_id,
+            "artifact_id": artifact_id,
+            "version": _string(data.get("version"), f"{label}.version"),
+            "platform": _string(data.get("platform"), f"{label}.platform").lower(),
+            "arch": _string(data.get("arch"), f"{label}.arch").lower(),
+        }
+        raw_digest = data.get("digest")
+        if raw_digest is not None:
+            conflicting = sorted({"artifact_type", "entrypoint", "sha256"} & set(data))
+            if conflicting:
+                raise ManifestError(
+                    f"{label}.digest must not be combined with: {', '.join(conflicting)}"
+                )
+            digest = _string(raw_digest, f"{label}.digest").lower()
+            if len(digest) != 64 or any(
+                char not in "0123456789abcdef" for char in digest
+            ):
+                raise ManifestError(f"{label}.digest must be a sha256 digest")
+            return cls(**common, digest=digest)
         artifact_type = _string(
             data.get("artifact_type"), f"{label}.artifact_type"
         ).lower()
@@ -183,11 +217,7 @@ class NodeLock:
         if len(sha256) != 64 or any(char not in "0123456789abcdef" for char in sha256):
             raise ManifestError(f"{label}.sha256 must be a sha256 digest")
         return cls(
-            node_id=safe_node_id,
-            artifact_id=artifact_id,
-            version=_string(data.get("version"), f"{label}.version"),
-            platform=_string(data.get("platform"), f"{label}.platform").lower(),
-            arch=_string(data.get("arch"), f"{label}.arch").lower(),
+            **common,
             artifact_type=artifact_type,
             entrypoint=entrypoint,
             sha256=sha256,


### PR DESCRIPTION
## Problem

Upstream `dev` can lock a Forge node only as a single-executable
`executable_tar_gz` archive. The RoboDojo G05 Skill needs two independently
versioned multi-file node bundles and must verify the exact installed payload.

## What / Fix

Add an optional `digest` form to a Skill node lock. For digest-locked bundles,
the installer verifies the embedded `node-manifest.json` (node id, artifact id,
version, digest and host) and resolves entrypoints from that manifest. The CLI
and environment builder handle both lock forms while the legacy
`executable_tar_gz` behaviour stays unchanged.

## Verification

- `python -m compileall -q PhyAgentOS` passed.
- `pytest -q tests/test_environment_injection.py tests/test_manager_flow_running.py tests/test_startup_timeout.py` passed: 19 tests.
- A targeted synthetic digest-bundle install check passed: manifest validation,
  installation, `load_entrypoints()` and executable lookup.
- `tests/test_forge_task_tool_serialization.py` was not run locally because the
  local pytest environment lacks `pytest-asyncio`; repository CI is still pending.
- No GPU, Isaac Sim, Agent or evaluation run was performed.