### PR TITLE
feat: add Atlas Cloud provider

### DIFF
--- a/PhyAgentOS/config/schema.py
+++ b/PhyAgentOS/config/schema.py
@@ -392,6 +392,7 @@ class ProvidersConfig(Base):
     anthropic: ProviderConfig = Field(default_factory=ProviderConfig)
     openai: ProviderConfig = Field(default_factory=ProviderConfig)
     openrouter: ProviderConfig = Field(default_factory=ProviderConfig)
+    atlas: ProviderConfig = Field(default_factory=ProviderConfig)  # Atlas Cloud gateway
     deepseek: ProviderConfig = Field(default_factory=ProviderConfig)
     groq: ProviderConfig = Field(default_factory=ProviderConfig)
     zhipu: ProviderConfig = Field(default_factory=ProviderConfig)

--- a/PhyAgentOS/providers/registry.py
+++ b/PhyAgentOS/providers/registry.py
@@ -109,6 +109,23 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         model_overrides=(),
         supports_prompt_caching=True,
     ),
+    # Atlas Cloud: OpenAI-compatible gateway using catalog model IDs directly.
+    ProviderSpec(
+        name="atlas",
+        keywords=("atlas", "atlascloud"),
+        env_key="OPENAI_API_KEY",
+        display_name="Atlas Cloud",
+        litellm_prefix="openai",
+        skip_prefixes=(),
+        env_extras=(),
+        is_gateway=True,
+        is_local=False,
+        detect_by_key_prefix="",
+        detect_by_base_keyword="atlascloud.ai",
+        default_api_base="https://api.atlascloud.ai/v1",
+        strip_model_prefix=False,
+        model_overrides=(),
+    ),
     # AiHubMix: global gateway, OpenAI-compatible interface.
     # strip_model_prefix=True: it doesn't understand "anthropic/claude-3",
     # so we strip to bare "claude-3" then re-prefix as "openai/claude-3".

--- a/README.md
+++ b/README.md
@@ -222,6 +222,25 @@ it may be empty when all artifacts are installed from local bundles or a supplie
 PAOS connects only to the Gateway URL in the manifest of the explicitly started, healthy Skill
 Runtime. It never starts or downloads a concrete Skill merely because the Agent starts.
 
+Atlas Cloud can be selected as an optional OpenAI-compatible provider without changing the
+default configuration. Use a model ID from the live Atlas Cloud catalog:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "model": "Qwen/Qwen3-235B-A22B-Instruct-2507",
+      "provider": "atlas"
+    }
+  },
+  "providers": {
+    "atlas": {
+      "apiKey": "YOUR_ATLASCLOUD_API_KEY"
+    }
+  }
+}
+```
+
 ### 4. Start the Agent
 
 Start the required installed Skill Runtime first, then choose one of the PAOS entry points:

--- a/README_zh.md
+++ b/README_zh.md
@@ -218,6 +218,25 @@ paos onboard
 或显式静态 index 安装时可留空。PAOS 只连接到已显式启动且健康的 Skill Runtime manifest
 所声明的 Gateway URL；启动 Agent 不会隐式启动或下载某个具体 Skill。
 
+Atlas Cloud 可作为 OpenAI 兼容的可选 Provider 使用，不会改变默认配置。请使用 Atlas Cloud
+实时模型目录中的模型 ID：
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "model": "Qwen/Qwen3-235B-A22B-Instruct-2507",
+      "provider": "atlas"
+    }
+  },
+  "providers": {
+    "atlas": {
+      "apiKey": "YOUR_ATLASCLOUD_API_KEY"
+    }
+  }
+}
+```
+
 ### 4. 启动 Agent
 
 先启动所需的已安装 Skill Runtime，再选择一种 PAOS 入口：

--- a/tests/test_atlas_provider.py
+++ b/tests/test_atlas_provider.py
@@ -1,0 +1,35 @@
+"""Tests for the optional Atlas Cloud provider configuration."""
+
+from PhyAgentOS.config.schema import Config
+from PhyAgentOS.providers.litellm_provider import LiteLLMProvider
+from PhyAgentOS.providers.registry import find_by_name
+
+
+def test_atlas_provider_uses_catalog_model_ids_with_default_api_base() -> None:
+    model = "Qwen/Qwen3-235B-A22B-Instruct-2507"
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"model": model, "provider": "atlas"}},
+            "providers": {"atlas": {"apiKey": "test-key"}},
+        }
+    )
+
+    assert config.get_provider_name() == "atlas"
+    assert config.get_api_key() == "test-key"
+    assert config.get_api_base() == "https://api.atlascloud.ai/v1"
+
+
+def test_atlas_provider_routes_through_litellm_openai_compatibility() -> None:
+    provider = LiteLLMProvider(provider_name="atlas")
+
+    assert provider._resolve_model("Qwen/Qwen3-235B-A22B-Instruct-2507") == (
+        "openai/Qwen/Qwen3-235B-A22B-Instruct-2507"
+    )
+
+
+def test_atlas_provider_is_detected_from_its_api_base() -> None:
+    spec = find_by_name("atlas")
+
+    assert spec is not None
+    assert spec.is_gateway
+    assert spec.default_api_base == "https://api.atlascloud.ai/v1"


### PR DESCRIPTION
## Summary

- register Atlas Cloud as an optional OpenAI-compatible gateway
- expose Atlas Cloud in the provider configuration schema
- document opt-in setup in the English and Chinese READMEs
- cover default API base, provider selection, and LiteLLM model routing

Existing provider defaults remain unchanged. Users select Atlas explicitly and supply a model ID from the live catalog.

## Validation

- `uv run --extra dev pytest -q tests/test_atlas_provider.py` (3 passed)
- `uv run --extra dev pytest -q` (24 passed)
- `uv run --extra dev ruff check .`
- `uv build`
- one live Atlas Cloud chat-completions smoke request succeeded (no retry)